### PR TITLE
Data table integration

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -223,6 +223,24 @@ XGB_DLL int XGDMatrixCreateFromMat_omp(const float *data,
                                        DMatrixHandle *out,
                                        int nthread);
 /*!
+ * \brief create matrix content from dt
+ * \param pointer to pointer to column data
+ * \param pointer to strings of feature names
+ * \param pointer to strings of feature stypes
+ * \param nrow number of rows
+ * \param ncol number columns
+ * \param out created dmatrix
+ * \param nthread number of threads (up to maximum cores available, if <=0 use all cores)
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixCreateFromdt(const void** data,
+                                  const wchar_t ** feature_names,
+                                  const wchar_t ** feature_stypes,
+                                  bst_ulong nrow,
+                                  bst_ulong ncol,
+                                  DMatrixHandle* out,
+                                  int nthread);
+/*!
  * \brief create a new dmatrix from sliced content of existing matrix
  * \param handle instance of data matrix to be sliced
  * \param idxset index set
@@ -264,7 +282,9 @@ XGB_DLL int XGDMatrixSetFloatInfo(DMatrixHandle handle,
  * \brief set uint32 vector to a content in info
  * \param handle a instance of data matrix
  * \param field field name
- * \param array pointer to float vector
+ * \param array pointer to pointer to columns
+ * \param feature_names pointer to strings
+ * \param feature_types pointer to strings
  * \param len length of array
  * \return 0 when success, -1 when failure happens
  */

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -33,6 +33,7 @@ except ImportError:
 # pandas
 try:
     from pandas import DataFrame
+    from pandas import Series
     PANDAS_INSTALLED = True
 except ImportError:
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -282,7 +282,7 @@ def _maybe_dt_label(label):
         raise ValueError('DataTable for label or weight cannot have multiple columns')
 
     # FIXME: below [0,:] due to bug in dt
-    label = label.tonumpy()[0,:].astype('float')  # extract first column
+    label = label.tonumpy()[:,0].astype('float')  # extract first column
 
     return label
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -231,7 +231,7 @@ class DMatrix(object):
 
         Parameters
         ----------
-        data : string/numpy array/scipy.sparse/pd.DataFrame
+        data : string/numpy array/scipy.sparse/pd.DataFrame/DataTable
             Data source of DMatrix.
             When data is string type, it represents the path libsvm format txt file,
             or binary file that xgboost can read from.
@@ -268,6 +268,8 @@ class DMatrix(object):
             self._init_from_csr(data)
         elif isinstance(data, scipy.sparse.csc_matrix):
             self._init_from_csc(data)
+        elif isinstance(data, np.ndarray):
+            self._init_from_npy2d(data, missing, nthread)
         elif isinstance(data, np.ndarray):
             self._init_from_npy2d(data, missing, nthread)
         else:

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -336,7 +336,10 @@ class DMatrix(object):
             label  = _maybe_dt_label(label)
             weight = _maybe_dt_label(weight)
             if data is not None:
+                import time
+                tmp = time.time()
                 self._init_from_dt(data, feature_names, feature_stypes, nthread) # missing is well-defined for dt
+                #print("init_from_dt Time: %s seconds" % (str(time.time() - tmp)))
 
         else:
             data, feature_names, feature_types = _maybe_pandas_data(data,
@@ -363,12 +366,18 @@ class DMatrix(object):
                     raise TypeError('can not initialize DMatrix from {}'.format(type(data).__name__))
         if label is not None:
             if isinstance(label, np.ndarray):
+                import time
+                tmp = time.time()
                 self.set_label_npy2d(label)
+                #print("set_label_npy2d Time: %s seconds" % (str(time.time() - tmp)))
             else:
                 self.set_label(label)
         if weight is not None:
             if isinstance(weight, np.ndarray):
+                import time
+                tmp = time.time()
                 self.set_weight_npy2d(weight)
+                #print("set_weight_npy2d Time: %s seconds" % (str(time.time() - tmp)))
             else:
                 self.set_weight(weight)
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -231,7 +231,7 @@ DT_TYPE_MAPPER = {'bool': 'bool', 'int': 'int', 'real': 'float'}
 
 
 def _maybe_dt_data(data, feature_names, feature_types):
-    if not HAVE_DT or not isinstance(data, dt.DataTable):
+    if not HAVE_DT or not isinstance(data, dt.DataTable) or data is None:
         return data, feature_names, feature_types
 
     data_types = data.types
@@ -269,8 +269,8 @@ def _maybe_dt_label(label):
     """ Extract internal data from dt.DataTable for DMatrix label """
 
     ptrs, feature_names, feature_stypes = _maybe_dt_data(label, None, None)
-    if len(ptrs) > 1:
-        raise ValueError('DataTable for label cannot have multiple columns')
+    if ptrs is not None and len(ptrs) > 1:
+        raise ValueError('DataTable for label or weight cannot have multiple columns')
     return ptrs, feature_names, feature_stypes
 
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -281,7 +281,7 @@ def _maybe_dt_label(label):
     if ptrs is not None and ncols > 1:
         raise ValueError('DataTable for label or weight cannot have multiple columns')
 
-    # FIXME: below [0,:] due to bug in dt
+    # below requires new dt version
     label = label.tonumpy()[:,0].astype('float')  # extract first column
 
     return label

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -585,12 +585,12 @@ bool dt_is_missing_and_get_value(datacol_struct *d, int i, float *value)
     // order of likelihood
     switch(d->datacoltype){
         case 0:
-            if(!std::isfinite(*value)) return true;
+            if(!std::isfinite(d->datacol_float[i])) return true;
             *value = static_cast<float>(d->datacol_float[i]);
             return false;
             break;
         case 1:
-            if(!std::isfinite(*value)) return true;
+            if(!std::isfinite(d->datacol_double[i])) return true;
             *value = static_cast<float>(d->datacol_double[i]);
             return false;
             break;

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -516,6 +516,7 @@ XGB_DLL int XGDMatrixCreateFromMat_omp(const bst_float* data,
 }
 
 class data_struct{
+  public:
   double ** data_double;
   float ** data_float;
   bool ** data_bool;
@@ -524,7 +525,6 @@ class data_struct{
   int32_t ** data_int4;
   int64_t ** data_int8;
 
-  public:
   data_struct(void **data):
             data_bool(reinterpret_cast<bool**>(data)),
             data_int1(reinterpret_cast<int8_t**>(data)),
@@ -541,25 +541,25 @@ class data_struct{
 float get_dt_value(data_struct *d, wchar_t * stype, int i)
 {
     // order of likelihood
-    if(wcscmp(stype,"f4r")==0){
+    if(wcscmp(stype,L"f4r")==0){
      return static_cast<float>(*d->data_float[i]);
     }
-    else if(wcscmp(stype,"f8r")==0){
+    else if(wcscmp(stype,L"f8r")==0){
      return static_cast<float>(*d->data_double[i]);
     }
-    else if(wcscmp(stype,"i1b")==0){
+    else if(wcscmp(stype,L"i1b")==0){
      return static_cast<float>(*d->data_bool[i]);
     }
-    else if(wcscmp(stype,"i4i")==0){
+    else if(wcscmp(stype,L"i4i")==0){
      return static_cast<float>(*d->data_int4[i]);
     }
-    else if(wcscmp(stype,"i1i")==0){
+    else if(wcscmp(stype,L"i1i")==0){
      return static_cast<float>(*d->data_int1[i]);
     }
-    else if(wcscmp(stype,"i2i")==0){
+    else if(wcscmp(stype,L"i2i")==0){
      return static_cast<float>(*d->data_int2[i]);
     }
-    else if(wcscmp(stype,"i8i")==0){
+    else if(wcscmp(stype,L"i8i")==0){
      return static_cast<float>(*d->data_int8[i]);
     }
     else{
@@ -572,25 +572,25 @@ float get_dt_value(data_struct *d, wchar_t * stype, int i)
 bool is_dt_missing(data_struct *d, wchar_t * stype, int i)
 {
     // order of likelihood
-    if(wcscmp(stype,"f4r")==0 && !std::isfinite(*d->data_float[i])){ // GETNA<float>
+    if(wcscmp(stype,L"f4r")==0 && !std::isfinite(*d->data_float[i])){ // GETNA<float>
         return true;
     }
-    else if(wcscmp(stype,"f8r")==0 && !std::isfinite(*d->data_double[i])){ // GETNA<double>
+    else if(wcscmp(stype,L"f8r")==0 && !std::isfinite(*d->data_double[i])){ // GETNA<double>
         return true;
     }
-    else if(wcscmp(stype,"i1b")==0 && *d->data_bool[i]==GETNA<bool>()){
+    else if(wcscmp(stype,L"i1b")==0 && *d->data_bool[i]==GETNA<bool>()){
         return true;
     }
-    else if(wcscmp(stype,"i4i")==0 && *d->data_int4[i]==GETNA<int32_t>()){
+    else if(wcscmp(stype,L"i4i")==0 && *d->data_int4[i]==GETNA<int32_t>()){
         return true;
     }
-    else if(wcscmp(stype,"i1i")==0 && *d->data_int1[i]==GETNA<int8_t>()){
+    else if(wcscmp(stype,L"i1i")==0 && *d->data_int1[i]==GETNA<int8_t>()){
         return true;
     }
-    else if(wcscmp(stype,"i2i")==0 && *d->data_int2[i]==GETNA<int16_t>()){
+    else if(wcscmp(stype,L"i2i")==0 && *d->data_int2[i]==GETNA<int16_t>()){
         return true;
     }
-    else if(wcscmp(stype,"i8i")==0 && *d->data_int8[i]==GETNA<int64_t>()){
+    else if(wcscmp(stype,L"i8i")==0 && *d->data_int8[i]==GETNA<int64_t>()){
         return true;
     }
     else return false;
@@ -638,9 +638,10 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
     // Count elements per row, column by column
     for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
       data_struct d(data);
+      wchar_t * stype = feature_stypes[j];
 #pragma omp for schedule(static)
       for (omp_ulong i = 0; i < nrow; ++i) {
-        if (is_dt_missing(&d, feature_stypes[j][i], i)) {
+        if (is_dt_missing(&d, stype, i)) {
             // pass
         } else {
             mat.row_ptr_[i+1] ++;
@@ -681,13 +682,14 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
   {
     for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
       data_struct d(data);
+      wchar_t * stype = feature_stypes[j];
 #pragma omp for schedule(static)
       for (omp_ulong i = 0; i < nrow; ++i) {
         if (is_dt_missing(&d, feature_stypes[j][i], i)) {
           // pass
         } else{
           mat.row_data_[mat.row_ptr_[i] + matj[i]] =
-              RowBatch::Entry(j, get_dt_value(&d, feature_stypes[j][i], i));
+              RowBatch::Entry(j, get_dt_value(&d, stype, i));
           matj[i]++;
         }
       }

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -571,6 +571,8 @@ float get_dt_value(data_struct *d, wchar_t * stype, int i)
 
 bool is_dt_missing(data_struct *d, wchar_t * stype, int i)
 {
+    return false;
+    fwprintf(stderr,L"stype = %s", stype);fflush(stderr);
     // order of likelihood
     if(wcscmp(stype,L"f4r")==0 && !std::isfinite(*d->data_float[i])){ // GETNA<float>
         return true;
@@ -637,10 +639,12 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
     int ithread  = omp_get_thread_num();
     // Count elements per row, column by column
     for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
+      fprintf(stderr,"j=%zu\n",j); fflush(stderr);
       data_struct d(data);
       wchar_t * stype = const_cast<wchar_t *>(feature_stypes[j]);
 #pragma omp for schedule(static)
       for (omp_ulong i = 0; i < nrow; ++i) {
+        fprintf(stderr,"i=%zu\n",i); fflush(stderr);
         if (is_dt_missing(&d, stype, i)) {
             // pass
         } else {

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -563,7 +563,7 @@ float get_dt_value(data_struct *d, wchar_t * stype, int i)
      return static_cast<float>(*d->data_int8[i]);
     }
     else{
-        fwprintf(stderr,"Unknown type %s", stype);
+        fwprintf(stderr,L"Unknown type %s", stype);
         exit(1);
     }
 }

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -518,20 +518,20 @@ class data_struct{
   double ** data_double;
   float ** data_float;
   bool ** data_bool;
-  int8 ** data_int1;
-  int16 ** data_int2;
-  int32 ** data_int4;
-  int64 ** data_int8;
+  int8_t ** data_int1;
+  int16_t ** data_int2;
+  int32_t ** data_int4;
+  int64_t ** data_int8;
 
   public:
   data_struct(void **data):
-            data_bool(reinterpret_cast<const bool**>(data)),
-            data_int1(reinterpret_cast<const int8**>(data)),
-            data_int2(reinterpret_cast<const int16**>(data)),
-            data_int4(reinterpret_cast<const int32**>(data)),
-            data_int8(reinterpret_cast<const int64**>(data)),
-            data_double(reinterpret_cast<const double**>(data)),
-            data_float(reinterpret_cast<const float**>(data)){};
+            data_bool(reinterpret_cast<bool**>(data)),
+            data_int1(reinterpret_cast<int8_t**>(data)),
+            data_int2(reinterpret_cast<int16_t**>(data)),
+            data_int4(reinterpret_cast<int32_t**>(data)),
+            data_int8(reinterpret_cast<int64_t**>(data)),
+            data_double(reinterpret_cast<double**>(data)),
+            data_float(reinterpret_cast<float**>(data)){};
 //  ~data_struct() {}
 }
 
@@ -593,7 +593,7 @@ bool is_dt_missing(data_struct *d, int i)
         return true;
     }
     else return false;
-}
+};
 
 #define DEBUGTIME 0
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -515,84 +515,129 @@ XGB_DLL int XGDMatrixCreateFromMat_omp(const bst_float* data,
   API_END();
 }
 
-class data_struct{
-  public:
-  double ** data_double;
-  float ** data_float;
-  bool ** data_bool;
-  int8_t ** data_int1;
-  int16_t ** data_int2;
-  int32_t ** data_int4;
-  int64_t ** data_int8;
 
-  data_struct(void **data):
-            data_bool(reinterpret_cast<bool**>(data)),
-            data_int1(reinterpret_cast<int8_t**>(data)),
-            data_int2(reinterpret_cast<int16_t**>(data)),
-            data_int4(reinterpret_cast<int32_t**>(data)),
-            data_int8(reinterpret_cast<int64_t**>(data)),
-            data_double(reinterpret_cast<double**>(data)),
-            data_float(reinterpret_cast<float**>(data)){};
-//  ~data_struct() {}
+
+class datacol_struct{
+  public:
+  double * datacol_double;
+  float * datacol_float;
+  bool * datacol_bool;
+  int8_t * datacol_int1;
+  int16_t * datacol_int2;
+  int32_t * datacol_int4;
+  int64_t * datacol_int8;
+  wchar_t * stype;
+  int datacoltype;
+  int whichj;
+// const double * datacol = reinterpret_cast<const double**>(data)[j];
+  datacol_struct(void **data, const wchar_t ** feature_stypes, int j):
+            datacol_bool(reinterpret_cast<bool**>(data)[j]),
+            datacol_int1(reinterpret_cast<int8_t**>(data)[j]),
+            datacol_int2(reinterpret_cast<int16_t**>(data)[j]),
+            datacol_int4(reinterpret_cast<int32_t**>(data)[j]),
+            datacol_int8(reinterpret_cast<int64_t**>(data)[j]),
+            datacol_double(reinterpret_cast<double**>(data)[j]),
+            datacol_float(reinterpret_cast<float**>(data)[j]){
+
+                whichj = j;
+
+                stype = const_cast<wchar_t *>(feature_stypes[j]);
+
+                if(wcscmp(stype,L"f4r")==0){
+                   datacoltype = 0;
+                }
+                else if(wcscmp(stype,L"f8r")==0){
+                   datacoltype = 1;
+                }
+                else if(wcscmp(stype,L"i1b")==0){
+                   datacoltype = 2;
+                }
+                else if(wcscmp(stype,L"i4i")==0){
+                   datacoltype = 3;
+                }
+                else if(wcscmp(stype,L"i1i")==0){
+                   datacoltype = 4;
+                }
+                else if(wcscmp(stype,L"i2i")==0){
+                   datacoltype = 5;
+                }
+                else if(wcscmp(stype,L"i8i")==0){
+                   datacoltype = 6;
+                }
+                else{
+                    fwprintf(stderr,L"Unknown type %s", stype);
+                    exit(1);
+                }
+//                fprintf(stderr,"chose datacoltype=%d for j=%d\n",datacoltype,j); fflush(stderr);
+            };
+//  ~datacol_struct() {}
 };
 
 // map dt stype string to C ctype for casting purposes
 // {'i1b': 'bool', 'i1i': 'int', 'i2i': 'int', 'i4i': 'int', 'i8i': 'int', 'f4r': 'float', 'f8r': 'float'}
-float get_dt_value(data_struct *d, wchar_t * stype, int i)
+float get_dt_value(datacol_struct *d, int i)
 {
+//    fprintf(stderr,"using2 datacoltype=%d for i=%d\n",d->datacoltype,i); fflush(stderr);
+
     // order of likelihood
-    if(wcscmp(stype,L"f4r")==0){
-     return static_cast<float>(*d->data_float[i]);
-    }
-    else if(wcscmp(stype,L"f8r")==0){
-     return static_cast<float>(*d->data_double[i]);
-    }
-    else if(wcscmp(stype,L"i1b")==0){
-     return static_cast<float>(*d->data_bool[i]);
-    }
-    else if(wcscmp(stype,L"i4i")==0){
-     return static_cast<float>(*d->data_int4[i]);
-    }
-    else if(wcscmp(stype,L"i1i")==0){
-     return static_cast<float>(*d->data_int1[i]);
-    }
-    else if(wcscmp(stype,L"i2i")==0){
-     return static_cast<float>(*d->data_int2[i]);
-    }
-    else if(wcscmp(stype,L"i8i")==0){
-     return static_cast<float>(*d->data_int8[i]);
-    }
-    else{
-        fwprintf(stderr,L"Unknown type %s", stype);
-        exit(1);
+    switch(d->datacoltype){
+        case 0:
+          return static_cast<float>(d->datacol_float[i]);
+          break;
+        case 1:
+          return static_cast<float>(d->datacol_double[i]);
+          break;
+        case 2:
+          return static_cast<float>(d->datacol_bool[i]);
+          break;
+        case 3:
+          return static_cast<float>(d->datacol_int4[i]);
+          break;
+        case 4:
+          return static_cast<float>(d->datacol_int1[i]);
+          break;
+        case 5:
+          return static_cast<float>(d->datacol_int2[i]);
+          break;
+        case 6:
+          return static_cast<float>(d->datacol_int8[i]);
+          break;
+        default:
+          wprintf(L"Unknown type %s", d->stype);
+          fprintf(stderr,"Unknown datacoltype=%d\n",d->datacoltype);
+          fflush(stderr);
+          fflush(stdout);
+          exit(1);
     }
 }
 
 
-bool is_dt_missing(data_struct *d, wchar_t * stype, int i)
+bool is_dt_missing(datacol_struct *d, int i)
 {
-    return false;
-    fwprintf(stderr,L"stype = %s", stype);fflush(stderr);
+//    fprintf(stderr,"using1 datacoltype=%d for i=%d result=%g\n",d->datacoltype,i, d->datacol_double[i]); fflush(stderr);
+
+    // return false;
+    // fwprintf(stderr,L"stype = %s", stype);fflush(stderr);
     // order of likelihood
-    if(wcscmp(stype,L"f4r")==0 && !std::isfinite(*d->data_float[i])){ // GETNA<float>
+    if(d->datacoltype==0 && !std::isfinite(d->datacol_float[i])){ // GETNA<float>
         return true;
     }
-    else if(wcscmp(stype,L"f8r")==0 && !std::isfinite(*d->data_double[i])){ // GETNA<double>
+    else if(d->datacoltype==1 && !std::isfinite(d->datacol_double[i])){ // GETNA<double>
         return true;
     }
-    else if(wcscmp(stype,L"i1b")==0 && *d->data_bool[i]==GETNA<bool>()){
+    else if(d->datacoltype==2 && d->datacol_bool[i]==GETNA<bool>()){
         return true;
     }
-    else if(wcscmp(stype,L"i4i")==0 && *d->data_int4[i]==GETNA<int32_t>()){
+    else if(d->datacoltype==3 && d->datacol_int4[i]==GETNA<int32_t>()){
         return true;
     }
-    else if(wcscmp(stype,L"i1i")==0 && *d->data_int1[i]==GETNA<int8_t>()){
+    else if(d->datacoltype==4 && d->datacol_int1[i]==GETNA<int8_t>()){
         return true;
     }
-    else if(wcscmp(stype,L"i2i")==0 && *d->data_int2[i]==GETNA<int16_t>()){
+    else if(d->datacoltype==5 && d->datacol_int2[i]==GETNA<int16_t>()){
         return true;
     }
-    else if(wcscmp(stype,L"i8i")==0 && *d->data_int8[i]==GETNA<int64_t>()){
+    else if(d->datacoltype==6 && d->datacol_int8[i]==GETNA<int64_t>()){
         return true;
     }
     else return false;
@@ -620,6 +665,28 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
   // copy pointer
   void ** data = const_cast<void **>(data0);
 
+  if(0){ // DEBUG
+    int j=0;
+    int i=0;
+    double * datacol = reinterpret_cast<double**>(data)[j];
+    fprintf(stderr,"datacol00=%g\n",datacol[i]);
+    fprintf(stderr,"HERE1\n");
+    wprintf(L"stype0=%s\n",feature_stypes[j]);
+    if(wcscmp(feature_stypes[j],L"f8r")==0){
+       fprintf(stderr,"HEREINSIDE1\n");
+    }
+    else fprintf(stderr,"HEREINSIDE2\n");
+    if(wcscmp(feature_stypes[j],L"f4r")==0){
+       fprintf(stderr,"HEREINSIDE1f4r\n");
+    }
+    else fprintf(stderr,"HEREINSIDE2f4r\n");
+    wprintf(L"stype0b=%s\n",feature_stypes[j+1]);
+    fprintf(stderr,"HERE2\n");
+    fwprintf(stderr,L"HERE3\n");
+    wprintf(L"HERE4\n");
+    fflush(stderr);
+    exit(0);
+  }
 
   API_BEGIN();
   const int nthreadmax = std::max(omp_get_num_procs() / 2 - 1, 1);
@@ -639,19 +706,17 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
     int ithread  = omp_get_thread_num();
     // Count elements per row, column by column
     for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
-      fprintf(stderr,"j=%zu\n",j); fflush(stderr);
-      data_struct d(data);
-      wchar_t * stype = const_cast<wchar_t *>(feature_stypes[j]);
+      //fprintf(stderr,"j=%zu\n",j); fflush(stderr);
+      datacol_struct d(data, feature_stypes, j);
 #pragma omp for schedule(static)
       for (omp_ulong i = 0; i < nrow; ++i) {
-        fprintf(stderr,"i=%zu\n",i); fflush(stderr);
-        if (is_dt_missing(&d, stype, i)) {
+        //fprintf(stderr,"i=%zu\n",i); fflush(stderr);
+        if (is_dt_missing(&d, i)) {
             // pass
         } else {
             mat.row_ptr_[i+1] ++;
         }
       }
-      data+=1; // update pointer position to array of pointers
     }
   }
   #if(DEBUGTIME)
@@ -685,19 +750,17 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
 #pragma omp parallel num_threads(nthread)
   {
     for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
-      data_struct d(data);
-      wchar_t * stype = const_cast<wchar_t *>(feature_stypes[j]);
+      datacol_struct d(data, feature_stypes, j);
 #pragma omp for schedule(static)
       for (omp_ulong i = 0; i < nrow; ++i) {
-        if (is_dt_missing(&d, stype, i)) {
+        if (is_dt_missing(&d, i)) {
           // pass
         } else{
           mat.row_data_[mat.row_ptr_[i] + matj[i]] =
-              RowBatch::Entry(j, get_dt_value(&d, stype, i));
+              RowBatch::Entry(j, get_dt_value(&d, i));
           matj[i]++;
         }
       }
-      data+=1; // update pointer position to array of pointers
     }
   }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -20,7 +20,7 @@
 
 #include <sys/time.h>
 #include "dt.h" // For meaning of NAN for dt data
-
+#include <wchar.h>
 
 namespace xgboost {
 // booster wrapper for backward compatible reason.
@@ -541,26 +541,26 @@ class data_struct{
 float get_dt_value(data_struct *d, wchar_t * stype, int i)
 {
     // order of likelihood
-    if(strcmp(stype,"f4r")==0){
-     return static_cast<float>(d->*data_float[i]);
+    if(wcscmp(stype,"f4r")==0){
+     return static_cast<float>(*d->data_float[i]);
     }
-    else if(strcmp(stype,"f8r")==0){
-     return static_cast<float>(d->*data_double[i]);
+    else if(wcscmp(stype,"f8r")==0){
+     return static_cast<float>(*d->data_double[i]);
     }
-    else if(strcmp(stype,"i1b")==0){
-     return static_cast<float>(d->*data_bool[i]);
+    else if(wcscmp(stype,"i1b")==0){
+     return static_cast<float>(*d->data_bool[i]);
     }
-    else if(strcmp(stype,"i4i")==0){
-     return static_cast<float>(d->*data_int4[i]);
+    else if(wcscmp(stype,"i4i")==0){
+     return static_cast<float>(*d->data_int4[i]);
     }
-    else if(strcmp(stype,"i1i")==0){
-     return static_cast<float>(d->*data_int1[i]);
+    else if(wcscmp(stype,"i1i")==0){
+     return static_cast<float>(*d->data_int1[i]);
     }
-    else if(strcmp(stype,"i2i")==0){
-     return static_cast<float>(d->*data_int2[i]);
+    else if(wcscmp(stype,"i2i")==0){
+     return static_cast<float>(*d->data_int2[i]);
     }
-    else if(strcmp(stype,"i8i")==0){
-     return static_cast<float>(d->*data_int8[i]);
+    else if(wcscmp(stype,"i8i")==0){
+     return static_cast<float>(*d->data_int8[i]);
     }
     else{
         fprintf(stderr,"Unknown type %s", stype);
@@ -572,25 +572,25 @@ float get_dt_value(data_struct *d, wchar_t * stype, int i)
 bool is_dt_missing(data_struct *d, wchar_t * stype, int i)
 {
     // order of likelihood
-    if(strcmp(stype,"f4r")==0 && !std::isfinite(*d->data_float[i])){ // GETNA<float>
+    if(wcscmp(stype,"f4r")==0 && !std::isfinite(*d->data_float[i])){ // GETNA<float>
         return true;
     }
-    else if(strcmp(stype,"f8r")==0 && !std::isfinite(*d->data_double[i])){ // GETNA<double>
+    else if(wcscmp(stype,"f8r")==0 && !std::isfinite(*d->data_double[i])){ // GETNA<double>
         return true;
     }
-    else if(strcmp(stype,"i1b")==0 && *d->data_bool[i]==GETNA<bool>()){
+    else if(wcscmp(stype,"i1b")==0 && *d->data_bool[i]==GETNA<bool>()){
         return true;
     }
-    else if(strcmp(stype,"i4i")==0 && *d->data_int4[i]==GETNA<int32_t>()){
+    else if(wcscmp(stype,"i4i")==0 && *d->data_int4[i]==GETNA<int32_t>()){
         return true;
     }
-    else if(strcmp(stype,"i1i")==0 && *d->data_int1[i]==GETNA<int8_t>()){
+    else if(wcscmp(stype,"i1i")==0 && *d->data_int1[i]==GETNA<int8_t>()){
         return true;
     }
-    else if(strcmp(stype,"i2i")==0 && *d->data_int2[i]==GETNA<int16_t>()){
+    else if(wcscmp(stype,"i2i")==0 && *d->data_int2[i]==GETNA<int16_t>()){
         return true;
     }
-    else if(strcmp(stype,"i8i")==0 && *d->data_int8[i]==GETNA<int64_t>()){
+    else if(wcscmp(stype,"i8i")==0 && *d->data_int8[i]==GETNA<int64_t>()){
         return true;
     }
     else return false;

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -19,8 +19,7 @@
 #include "../common/group_data.h"
 
 #include <sys/time.h>
-#include "dt.h" // For meaning of NAN for dt data
-#include <wchar.h>
+#include "dt.h" // Functions for handling datatable
 
 namespace xgboost {
 // booster wrapper for backward compatible reason.
@@ -516,119 +515,7 @@ XGB_DLL int XGDMatrixCreateFromMat_omp(const bst_float* data,
 }
 
 
-
-class datacol_struct{
-  public:
-  double * datacol_double;
-  float * datacol_float;
-  bool * datacol_bool;
-  int8_t * datacol_int1;
-  int16_t * datacol_int2;
-  int32_t * datacol_int4;
-  int64_t * datacol_int8;
-  wchar_t * stype;
-  int datacoltype;
-  int whichj;
-// const double * datacol = reinterpret_cast<const double**>(data)[j];
-  datacol_struct(void **data, const wchar_t ** feature_stypes, int j):
-            datacol_bool(reinterpret_cast<bool**>(data)[j]),
-            datacol_int1(reinterpret_cast<int8_t**>(data)[j]),
-            datacol_int2(reinterpret_cast<int16_t**>(data)[j]),
-            datacol_int4(reinterpret_cast<int32_t**>(data)[j]),
-            datacol_int8(reinterpret_cast<int64_t**>(data)[j]),
-            datacol_double(reinterpret_cast<double**>(data)[j]),
-            datacol_float(reinterpret_cast<float**>(data)[j]){
-
-                whichj = j;
-
-                stype = const_cast<wchar_t *>(feature_stypes[j]);
-
-                if(wcscmp(stype,L"f4r")==0){
-                   datacoltype = 0;
-                }
-                else if(wcscmp(stype,L"f8r")==0){
-                   datacoltype = 1;
-                }
-                else if(wcscmp(stype,L"i1b")==0){
-                   datacoltype = 2;
-                }
-                else if(wcscmp(stype,L"i4i")==0){
-                   datacoltype = 3;
-                }
-                else if(wcscmp(stype,L"i1i")==0){
-                   datacoltype = 4;
-                }
-                else if(wcscmp(stype,L"i2i")==0){
-                   datacoltype = 5;
-                }
-                else if(wcscmp(stype,L"i8i")==0){
-                   datacoltype = 6;
-                }
-                else{
-                    fwprintf(stderr,L"Unknown type %s", stype);
-                    exit(1);
-                }
-//                fprintf(stderr,"chose datacoltype=%d for j=%d\n",datacoltype,j); fflush(stderr);
-            };
-//  ~datacol_struct() {}
-};
-
-// map dt stype string to C ctype for casting purposes
-// {'i1b': 'bool', 'i1i': 'int', 'i2i': 'int', 'i4i': 'int', 'i8i': 'int', 'f4r': 'float', 'f8r': 'float'}
-
-bool dt_is_missing_and_get_value(datacol_struct *d, int i, float *value)
-{
-//    fprintf(stderr,"using1 datacoltype=%d for i=%d result=%g\n",d->datacoltype,i, d->datacol_double[i]); fflush(stderr);
-
-    // return false;
-    // fwprintf(stderr,L"stype = %s", stype);fflush(stderr);
-    // order of likelihood
-    switch(d->datacoltype){
-        case 0:
-            if(!std::isfinite(d->datacol_float[i])) return true;
-            *value = static_cast<float>(d->datacol_float[i]);
-            return false;
-            break;
-        case 1:
-            if(!std::isfinite(d->datacol_double[i])) return true;
-            *value = static_cast<float>(d->datacol_double[i]);
-            return false;
-            break;
-        case 2:
-            if(d->datacol_bool[i]==GETNA<bool>()) return true;
-            *value = static_cast<float>(d->datacol_bool[i]);
-            return false;
-            break;
-        case 3:
-            if(d->datacol_int4[i]==GETNA<int32_t>()) return true;
-            *value = static_cast<float>(d->datacol_int4[i]);
-            return false;
-            break;
-        case 4:
-            if(d->datacol_int1[i]==GETNA<int8_t>()) return true;
-            *value = static_cast<float>(d->datacol_int1[i]);
-            return false;
-            break;
-        case 5:
-            if(d->datacol_int2[i]==GETNA<int16_t>()) return true;
-            *value = static_cast<float>(d->datacol_int2[i]);
-            return false;
-            break;
-        case 6:
-            if(d->datacol_int8[i]==GETNA<int64_t>()) return true;
-            *value = static_cast<float>(d->datacol_int8[i]);
-            return false;
-            break;
-        default:
-            wprintf(L"Unknown type %s", d->stype);
-            fprintf(stderr,"Unknown datacoltype=%d\n",d->datacoltype);
-            fflush(stderr);
-            fflush(stdout);
-            exit(1);
-    }
-}
-
-#define DEBUGTIME 0
+#define DEBUGTIME 1
 
 
 XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
@@ -649,29 +536,6 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
 
   // copy pointer
   void ** data = const_cast<void **>(data0);
-
-  if(0){ // DEBUG
-    int j=0;
-    int i=0;
-    double * datacol = reinterpret_cast<double**>(data)[j];
-    fprintf(stderr,"datacol00=%g\n",datacol[i]);
-    fprintf(stderr,"HERE1\n");
-    wprintf(L"stype0=%s\n",feature_stypes[j]);
-    if(wcscmp(feature_stypes[j],L"f8r")==0){
-       fprintf(stderr,"HEREINSIDE1\n");
-    }
-    else fprintf(stderr,"HEREINSIDE2\n");
-    if(wcscmp(feature_stypes[j],L"f4r")==0){
-       fprintf(stderr,"HEREINSIDE1f4r\n");
-    }
-    else fprintf(stderr,"HEREINSIDE2f4r\n");
-    wprintf(L"stype0b=%s\n",feature_stypes[j+1]);
-    fprintf(stderr,"HERE2\n");
-    fwprintf(stderr,L"HERE3\n");
-    wprintf(L"HERE4\n");
-    fflush(stderr);
-    exit(0);
-  }
 
   API_BEGIN();
   const int nthreadmax = std::max(omp_get_num_procs() / 2 - 1, 1);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -18,6 +18,8 @@
 #include "../common/io.h"
 #include "../common/group_data.h"
 
+#include "dt.h"
+
 namespace xgboost {
 // booster wrapper for backward compatible reason.
 class Booster {
@@ -542,18 +544,17 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data,
     int ithread  = omp_get_thread_num();
 
     // Count elements per row
+    for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
+      double * datacol = reinterpret_cast<const double**>(data)[j];
 #pragma omp for schedule(static)
-    for (omp_ulong i = 0; i < nrow; ++i) {
-      xgboost::bst_ulong nelem = 0;
-      for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
+      for (omp_ulong i = 0; i < nrow; ++i) {
         double missing = -1.0;
         if (reinterpret_cast<const double**>(data)[j][i]==missing) {
         // pass
         } else {
-          ++nelem;
+            mat.row_ptr_[i+1] ++;
         }
       }
-      mat.row_ptr_[i+1] = nelem;
     }
   }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -441,7 +441,7 @@ XGB_DLL int XGDMatrixCreateFromMat_omp(const bst_float* data,
   const int nthreadmax = std::max(omp_get_num_procs() / 2 - 1, 1);
   //  const int nthreadmax = omp_get_max_threads();
   if (nthread <= 0) nthread=nthreadmax;
-  nthread_orig = omp_get_max_threads();
+  int nthread_orig = omp_get_max_threads();
   omp_set_num_threads(nthread);
 
   std::unique_ptr<data::SimpleCSRSource> source(new data::SimpleCSRSource());
@@ -528,7 +528,7 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data,
   const int nthreadmax = std::max(omp_get_num_procs() / 2 - 1, 1);
   //  const int nthreadmax = omp_get_max_threads();
   if (nthread <= 0) nthread=nthreadmax;
-  nthread_orig = omp_get_max_threads();
+  int nthread_orig = omp_get_max_threads();
   omp_set_num_threads(nthread);
 
   std::unique_ptr<data::SimpleCSRSource> source(new data::SimpleCSRSource());

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -563,7 +563,7 @@ float get_dt_value(data_struct *d, wchar_t * stype, int i)
      return static_cast<float>(*d->data_int8[i]);
     }
     else{
-        fprintf(stderr,"Unknown type %s", stype);
+        fwprintf(stderr,"Unknown type %s", stype);
         exit(1);
     }
 }
@@ -638,7 +638,7 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
     // Count elements per row, column by column
     for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
       data_struct d(data);
-      wchar_t * stype = feature_stypes[j];
+      wchar_t * stype = const_cast<wchar_t *>(feature_stypes[j]);
 #pragma omp for schedule(static)
       for (omp_ulong i = 0; i < nrow; ++i) {
         if (is_dt_missing(&d, stype, i)) {
@@ -682,7 +682,7 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
   {
     for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
       data_struct d(data);
-      wchar_t * stype = feature_stypes[j];
+      wchar_t * stype = const_cast<wchar_t *>(feature_stypes[j]);
 #pragma omp for schedule(static)
       for (omp_ulong i = 0; i < nrow; ++i) {
         if (is_dt_missing(&d, feature_stypes[j][i], i)) {

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -685,7 +685,7 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
       wchar_t * stype = const_cast<wchar_t *>(feature_stypes[j]);
 #pragma omp for schedule(static)
       for (omp_ulong i = 0; i < nrow; ++i) {
-        if (is_dt_missing(&d, feature_stypes[j][i], i)) {
+        if (is_dt_missing(&d, stype, i)) {
           // pass
         } else{
           mat.row_data_[mat.row_ptr_[i] + matj[i]] =

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -514,76 +514,6 @@ XGB_DLL int XGDMatrixCreateFromMat_omp(const bst_float* data,
   API_END();
 }
 
-
-// map dt stype string to C ctype for casting purposes
-//int dtstring_to_ctype(wchar_t * string)
-//{
-// {'i1b': 'bool', 'i1i': 'int', 'i2i': 'int', 'i4i': 'int', 'i8i': 'int', 'f4r': 'float', 'f8r': 'float'}
-
-
-
-//}
-
-float get_dt_value(data_struct *d, int i)
-{
-    // order of likelihood
-    if(strcmp(stype,'f4r')==0){
-     return static_cast<float>(d->*data_float[i]);
-    }
-    else if(strcmp(stype,'f8r')==0){
-     return static_cast<float>(d->*data_double[i]);
-    }
-    else if(strcmp(stype,'i1b')==0){
-     return static_cast<float>(d->*data_bool[i]);
-    }
-    else if(strcmp(stype,'i4i')==0){
-     return static_cast<float>(d->*data_int4[i]);
-    }
-    else if(strcmp(stype,'i1i')==0){
-     return static_cast<float>(d->*data_int1[i]);
-    }
-    else if(strcmp(stype,'i2i')==0){
-     return static_cast<float>(d->*data_int2[i]);
-    }
-    else if(strcmp(stype,'i8i')==0){
-     return static_cast<float>(d->*data_int8[i]);
-    }
-    else{
-        fprintf(stderr,"Unknown type %s", stype);
-        exit(1);
-    }
-}
-
-
-bool is_dt_missing(data_struct *d, int i)
-{
-    // order of likelihood
-    if(strcmp(stype,'f4r')==0 && !isfinite(d->*data_float[i])){ // GETNA<float>
-        return true;
-    }
-    else if(strcmp(stype,'f8r')==0 && !isfinite(d->*data_double[i])){ // GETNA<double>
-        return true;
-    }
-    else if(strcmp(stype,'i1b')==0 && d->*data_bool[i]==GETNA<bool>()){
-        return true;
-    }
-    else if(strcmp(stype,'i4i')==0 && d->*data_int4[i]==GETNA<int32_t>()){
-        return true;
-    }
-    else if(strcmp(stype,'i1i')==0 && d->*data_int1[i]==GETNA<int8_t>()){
-        return true;
-    }
-    else if(strcmp(stype,'i2i')==0 && d->*data_int2[i]==GETNA<int16_t>()){
-        return true;
-    }
-    else if(strcmp(stype,'i8i')==0 && d->*data_int8[i]==GETNA<int64_t>()){
-        return true;
-    }
-    else return false;
-}
-
-#define DEBUGTIME 0
-
 class data_struct{
   double ** data_double;
   float ** data_float;
@@ -601,9 +531,72 @@ class data_struct{
             data_int4(reinterpret_cast<const int32**>(data)),
             data_int8(reinterpret_cast<const int64**>(data)),
             data_double(reinterpret_cast<const double**>(data)),
-            data_float(reinterpret_cast<const float**>(data)){}
+            data_float(reinterpret_cast<const float**>(data)){};
 //  ~data_struct() {}
 }
+
+// map dt stype string to C ctype for casting purposes
+// {'i1b': 'bool', 'i1i': 'int', 'i2i': 'int', 'i4i': 'int', 'i8i': 'int', 'f4r': 'float', 'f8r': 'float'}
+float get_dt_value(data_struct *d, int i)
+{
+    // order of likelihood
+    if(strcmp(stype,"f4r")==0){
+     return static_cast<float>(d->*data_float[i]);
+    }
+    else if(strcmp(stype,"f8r")==0){
+     return static_cast<float>(d->*data_double[i]);
+    }
+    else if(strcmp(stype,"i1b")==0){
+     return static_cast<float>(d->*data_bool[i]);
+    }
+    else if(strcmp(stype,"i4i")==0){
+     return static_cast<float>(d->*data_int4[i]);
+    }
+    else if(strcmp(stype,"i1i")==0){
+     return static_cast<float>(d->*data_int1[i]);
+    }
+    else if(strcmp(stype,"i2i")==0){
+     return static_cast<float>(d->*data_int2[i]);
+    }
+    else if(strcmp(stype,"i8i")==0){
+     return static_cast<float>(d->*data_int8[i]);
+    }
+    else{
+        fprintf(stderr,"Unknown type %s", stype);
+        exit(1);
+    }
+}
+
+
+bool is_dt_missing(data_struct *d, int i)
+{
+    // order of likelihood
+    if(strcmp(stype,"f4r")==0 && !isfinite(d->*data_float[i])){ // GETNA<float>
+        return true;
+    }
+    else if(strcmp(stype,"f8r")==0 && !isfinite(d->*data_double[i])){ // GETNA<double>
+        return true;
+    }
+    else if(strcmp(stype,"i1b")==0 && d->*data_bool[i]==GETNA<bool>()){
+        return true;
+    }
+    else if(strcmp(stype,"i4i")==0 && d->*data_int4[i]==GETNA<int32_t>()){
+        return true;
+    }
+    else if(strcmp(stype,"i1i")==0 && d->*data_int1[i]==GETNA<int8_t>()){
+        return true;
+    }
+    else if(strcmp(stype,"i2i")==0 && d->*data_int2[i]==GETNA<int16_t>()){
+        return true;
+    }
+    else if(strcmp(stype,"i8i")==0 && d->*data_int8[i]==GETNA<int64_t>()){
+        return true;
+    }
+    else return false;
+}
+
+#define DEBUGTIME 0
+
 
 XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
                                   const wchar_t ** feature_names,
@@ -672,7 +665,7 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data0,
 
   mat.row_data_.resize(mat.row_data_.size() + mat.row_ptr_.back());
 
-  #if(r DEBUGTIME)
+  #if(DEBUGTIME)
   gettimeofday(&tv,NULL); unsigned long time4 = 1000000 * tv.tv_sec + tv.tv_usec;
   fprintf(stderr,"C_TDIFF3=%g\n",(time4-time3)/1E6);
   #endif

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -508,6 +508,94 @@ XGB_DLL int XGDMatrixCreateFromMat_omp(const bst_float* data,
   API_END();
 }
 
+
+XGB_DLL int XGDMatrixCreateFromdt(const void** data,
+                                  const wchar_t ** feature_names,
+                                  const wchar_t ** feature_stypes,
+                                  xgboost::bst_ulong nrow,
+                                  xgboost::bst_ulong ncol,
+                                  DMatrixHandle* out,
+                                  int nthread) {
+  // avoid openmp unless enough data to be worth it to avoid overhead costs
+  if (nrow*ncol <= 10000*50) {
+     nthread = 1;
+  }
+
+  API_BEGIN();
+  const int nthreadmax = std::max(omp_get_num_procs() / 2 - 1, 1);
+  //  const int nthreadmax = omp_get_max_threads();
+  if (nthread <= 0) nthread=nthreadmax;
+  omp_set_num_threads(nthread);
+
+  std::unique_ptr<data::SimpleCSRSource> source(new data::SimpleCSRSource());
+  data::SimpleCSRSource& mat = *source;
+  mat.row_ptr_.resize(1+nrow);
+  mat.info.num_row = nrow;
+  mat.info.num_col = ncol;
+
+  // Check for errors in missing elements
+  // Count elements per row (to avoid otherwise need to copy)
+  bool nan_missing = false;
+  int *badnan;
+  badnan = new int[nthread];
+  for (int i = 0; i < nthread; i++) {
+    badnan[i] = 0;
+  }
+
+#pragma omp parallel num_threads(nthread)
+  {
+    int ithread  = omp_get_thread_num();
+
+    // Count elements per row
+#pragma omp for schedule(static)
+    for (omp_ulong i = 0; i < nrow; ++i) {
+      xgboost::bst_ulong nelem = 0;
+      for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
+        double missing = -1.0;
+        if (reinterpret_cast<const double**>(data)[j][i]==missing) {
+        // pass
+        } else {
+          ++nelem;
+        }
+      }
+      mat.row_ptr_[i+1] = nelem;
+    }
+  }
+  // Inform about any NaNs and resize data matrix
+  for (int i = 0; i < nthread; i++) {
+    CHECK(!badnan[i]) << "There are NAN in the matrix, however, you did not set missing=NAN";
+  }
+
+  // do cumulative sum (to avoid otherwise need to copy)
+  prefixsum_inplace(&mat.row_ptr_[0], mat.row_ptr_.size());
+  mat.row_data_.resize(mat.row_data_.size() + mat.row_ptr_.back());
+
+  // Fill data matrix (now that know size, no need for slow push_back())
+#pragma omp parallel num_threads(nthread)
+  {
+#pragma omp for schedule(static)
+    for (omp_ulong i = 0; i < nrow; ++i) {
+      xgboost::bst_ulong matj = 0;
+      for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
+        double missing = -1.0;
+        if (reinterpret_cast<const double**>(data)[j][i]==missing) {
+        } else{
+          mat.row_data_[mat.row_ptr_[i] + matj] =
+              RowBatch::Entry(j, reinterpret_cast<const double**>(data)[j][i]);
+          ++matj;
+        }
+      }
+    }
+  }
+
+  mat.info.num_nonzero = mat.row_data_.size();
+  *out  = new std::shared_ptr<DMatrix>(DMatrix::Create(std::move(source)));
+  API_END();
+}
+
+
+
+
 XGB_DLL int XGDMatrixSliceDMatrix(DMatrixHandle handle,
                                   const int* idxset,
                                   xgboost::bst_ulong len,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -585,12 +585,12 @@ bool dt_is_missing_and_get_value(datacol_struct *d, int i, float *value)
     // order of likelihood
     switch(d->datacoltype){
         case 0:
-            if(!std::isfinite(*value) return true;
+            if(!std::isfinite(*value)) return true;
             *value = static_cast<float>(d->datacol_float[i]);
             return false;
             break;
         case 1:
-            if(!std::isfinite(*value) return true;
+            if(!std::isfinite(*value)) return true;
             *value = static_cast<float>(d->datacol_double[i]);
             return false;
             break;
@@ -606,12 +606,12 @@ bool dt_is_missing_and_get_value(datacol_struct *d, int i, float *value)
             break;
         case 4:
             if(d->datacol_int1[i]==GETNA<int8_t>()) return true;
-            *value = static_cast<float>(d->datacol_int8[i]);
+            *value = static_cast<float>(d->datacol_int1[i]);
             return false;
             break;
         case 5:
             if(d->datacol_int2[i]==GETNA<int16_t>()) return true;
-            *value = static_cast<float>(d->datacol_int16[i]);
+            *value = static_cast<float>(d->datacol_int2[i]);
             return false;
             break;
         case 6:

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -576,10 +576,10 @@ XGB_DLL int XGDMatrixCreateFromdt(const void** data,
   // Fill data matrix (now that know size, no need for slow push_back())
 #pragma omp parallel num_threads(nthread)
   {
+    xgboost::bst_ulong matj[nrow] = {0};
     for (xgboost::bst_ulong j = 0; j < ncol; ++j) {
       const double * datacol = reinterpret_cast<const double**>(data)[j];
       double missing = GETNA<double>();
-      xgboost::bst_ulong matj[nrow] = {0};
 #pragma omp for schedule(static)
       for (omp_ulong i = 0; i < nrow; ++i) {
         if (datacol[i]==missing) {

--- a/src/c_api/dt.h
+++ b/src/c_api/dt.h
@@ -1,5 +1,6 @@
 
 //==============================================================================
+#include <wchar.h>
 
 /**
  * NA constants
@@ -41,3 +42,117 @@ template<> inline int64_t  GETNA() { return NA_I8; }
 //template<> inline uint32_t GETNA() { return NA_U4; }
 //template<> inline float    GETNA() { return NA_F4; }
 //template<> inline double   GETNA() { return NA_F8; }
+
+
+
+class datacol_struct{
+  public:
+  double * datacol_double;
+  float * datacol_float;
+  bool * datacol_bool;
+  int8_t * datacol_int1;
+  int16_t * datacol_int2;
+  int32_t * datacol_int4;
+  int64_t * datacol_int8;
+  wchar_t * stype;
+  int datacoltype;
+  int whichj;
+// const double * datacol = reinterpret_cast<const double**>(data)[j];
+  datacol_struct(void **data, const wchar_t ** feature_stypes, int j):
+            datacol_bool(reinterpret_cast<bool**>(data)[j]),
+            datacol_int1(reinterpret_cast<int8_t**>(data)[j]),
+            datacol_int2(reinterpret_cast<int16_t**>(data)[j]),
+            datacol_int4(reinterpret_cast<int32_t**>(data)[j]),
+            datacol_int8(reinterpret_cast<int64_t**>(data)[j]),
+            datacol_double(reinterpret_cast<double**>(data)[j]),
+            datacol_float(reinterpret_cast<float**>(data)[j]){
+
+                whichj = j;
+
+                stype = const_cast<wchar_t *>(feature_stypes[j]);
+
+                if(wcscmp(stype,L"f4r")==0){
+                   datacoltype = 0;
+                }
+                else if(wcscmp(stype,L"f8r")==0){
+                   datacoltype = 1;
+                }
+                else if(wcscmp(stype,L"i1b")==0){
+                   datacoltype = 2;
+                }
+                else if(wcscmp(stype,L"i4i")==0){
+                   datacoltype = 3;
+                }
+                else if(wcscmp(stype,L"i1i")==0){
+                   datacoltype = 4;
+                }
+                else if(wcscmp(stype,L"i2i")==0){
+                   datacoltype = 5;
+                }
+                else if(wcscmp(stype,L"i8i")==0){
+                   datacoltype = 6;
+                }
+                else{
+                    fwprintf(stderr,L"Unknown type %s", stype);
+                    exit(1);
+                }
+//                fprintf(stderr,"chose datacoltype=%d for j=%d\n",datacoltype,j); fflush(stderr);
+            };
+//  ~datacol_struct() {}
+};
+
+
+// map dt stype string to C ctype for casting purposes
+// {'i1b': 'bool', 'i1i': 'int', 'i2i': 'int', 'i4i': 'int', 'i8i': 'int', 'f4r': 'float', 'f8r': 'float'}
+
+bool dt_is_missing_and_get_value(datacol_struct *d, int i, float *value)
+{
+//    fprintf(stderr,"using1 datacoltype=%d for i=%d result=%g\n",d->datacoltype,i, d->datacol_double[i]); fflush(stderr);
+
+    // return false;
+    // fwprintf(stderr,L"stype = %s", stype);fflush(stderr);
+    // order of likelihood
+    switch(d->datacoltype){
+        case 0:
+            if(!std::isfinite(d->datacol_float[i])) return true;
+            *value = static_cast<float>(d->datacol_float[i]);
+            return false;
+            break;
+        case 1:
+            if(!std::isfinite(d->datacol_double[i])) return true;
+            *value = static_cast<float>(d->datacol_double[i]);
+            return false;
+            break;
+        case 2:
+            if(d->datacol_bool[i]==GETNA<bool>()) return true;
+            *value = static_cast<float>(d->datacol_bool[i]);
+            return false;
+            break;
+        case 3:
+            if(d->datacol_int4[i]==GETNA<int32_t>()) return true;
+            *value = static_cast<float>(d->datacol_int4[i]);
+            return false;
+            break;
+        case 4:
+            if(d->datacol_int1[i]==GETNA<int8_t>()) return true;
+            *value = static_cast<float>(d->datacol_int1[i]);
+            return false;
+            break;
+        case 5:
+            if(d->datacol_int2[i]==GETNA<int16_t>()) return true;
+            *value = static_cast<float>(d->datacol_int2[i]);
+            return false;
+            break;
+        case 6:
+            if(d->datacol_int8[i]==GETNA<int64_t>()) return true;
+            *value = static_cast<float>(d->datacol_int8[i]);
+            return false;
+            break;
+        default:
+            wprintf(L"Unknown type %s", d->stype);
+            fprintf(stderr,"Unknown datacoltype=%d\n",d->datacoltype);
+            fflush(stderr);
+            fflush(stdout);
+            exit(1);
+    }
+}

--- a/src/c_api/dt.h
+++ b/src/c_api/dt.h
@@ -1,0 +1,87 @@
+
+//==============================================================================
+
+/**
+ * NA constants
+ *
+ * Integer-based NAs can be compared by value (e.g. `x == NA_I4`), whereas
+ * floating-point NAs require special functions `ISNA_F4(x)` and `ISNA_F8(x)`.
+ */
+
+#define BIN_NAF4 0x7F8007A2u
+#define BIN_NAF8 0x7FF00000000007A2ull
+typedef union { uint64_t i; double d; } double_repr;
+typedef union { uint32_t i; float f; } float_repr;
+static inline float _nanf_(void) { float_repr x = { BIN_NAF4 }; return x.f; }
+static inline double _nand_(void) { double_repr x = { BIN_NAF8 }; return x.d; }
+#define NA_I1  (-128)
+#define NA_I2  (-32768)
+#define NA_I4  (-2147483647-1)
+#define NA_I8  (-9223372036854775807-1)
+#define NA_U1  255u
+#define NA_U2  65535u
+#define NA_U4  4294967295u
+#define NA_U8  18446744073709551615u
+#define NA_F4  _nanf_()
+#define NA_F8  _nand_()
+
+
+#define NA_F4_BITS 0x7F8007A2u
+#define NA_F8_BITS 0x7FF00000000007A2ull
+extern const int8_t   NA_I1;
+extern const int16_t  NA_I2;
+extern const int32_t  NA_I4;
+extern const int64_t  NA_I8;
+extern const uint8_t  NA_U1;
+extern const uint16_t NA_U2;
+extern const uint32_t NA_U4;
+extern const uint64_t NA_U8;
+extern       float    NA_F4;
+extern       double   NA_F8;
+
+int ISNA_F4(float x);
+int ISNA_F8(double x);
+
+#define ISNA_I1(x)  ((int8_t)(x)   == NA_I1)
+#define ISNA_I2(x)  ((int16_t)(x)  == NA_I2)
+#define ISNA_I4(x)  ((int32_t)(x)  == NA_I4)
+#define ISNA_I8(x)  ((int64_t)(x)  == NA_I8)
+#define ISNA_U1(x)  ((uint8_t)(x)  == NA_U1)
+#define ISNA_U2(x)  ((uint16_t)(x) == NA_U2)
+#define ISNA_U4(x)  ((uint32_t)(x) == NA_U4)
+
+/**
+ * GETNA function
+ * Template function that returns the appropriate NA_XX value based on the
+ * type of `T`. Returns NULL if `T` is incompatible.
+ */
+template <typename T>
+inline T        GETNA() { return NULL;  }
+template<> inline int8_t   GETNA() { return NA_I1; }
+template<> inline int16_t  GETNA() { return NA_I2; }
+template<> inline int32_t  GETNA() { return NA_I4; }
+template<> inline int64_t  GETNA() { return NA_I8; }
+template<> inline uint8_t  GETNA() { return NA_U1; }
+template<> inline uint16_t GETNA() { return NA_U2; }
+template<> inline uint32_t GETNA() { return NA_U4; }
+template<> inline float    GETNA() { return NA_F4; }
+template<> inline double   GETNA() { return NA_F8; }
+
+/**
+ * ISNA function
+ * Template function that uses the appropriate ISNA_XX macro/function based
+ * on the argument type. Returns true if type is invalid.
+ */
+template <typename T>
+inline bool ISNA(T)          { return true;       }
+template<> inline bool ISNA(int8_t x)   { return ISNA_I1(x); }
+template<> inline bool ISNA(int16_t x)  { return ISNA_I2(x); }
+template<> inline bool ISNA(int32_t x)  { return ISNA_I4(x); }
+template<> inline bool ISNA(int64_t x)  { return ISNA_I8(x); }
+template<> inline bool ISNA(uint8_t x)  { return ISNA_U1(x); }
+template<> inline bool ISNA(uint16_t x) { return ISNA_U2(x); }
+template<> inline bool ISNA(uint32_t x) { return ISNA_U4(x); }
+template<> inline bool ISNA(float x)    { return ISNA_F4(x); }
+template<> inline bool ISNA(double x)   { return ISNA_F8(x); }
+
+//==============================================================================

--- a/src/c_api/dt.h
+++ b/src/c_api/dt.h
@@ -9,22 +9,10 @@
  * floating-point NAs require special functions `ISNA_F4(x)` and `ISNA_F8(x)`.
  */
 
-//#define BIN_NAF4 0x7F8007A2u
-//#define BIN_NAF8 0x7FF00000000007A2ull
-//typedef union { uint64_t i; double d; } double_repr;
-//typedef union { uint32_t i; float f; } float_repr;
-//static inline float _nanf_(void) { float_repr x = { BIN_NAF4 }; return x.f; }
-//static inline double _nand_(void) { double_repr x = { BIN_NAF8 }; return x.d; }
 #define NA_I1  (-128)
 #define NA_I2  (-32768)
 #define NA_I4  (-2147483647-1)
 #define NA_I8  (-9223372036854775807-1)
-//#define NA_U1  255u
-//#define NA_U2  65535u
-//#define NA_U4  4294967295u
-//#define NA_U8  18446744073709551615u
-//#define NA_F4  _nanf_()
-//#define NA_F8  _nand_()
 
 /**
  * GETNA function
@@ -37,11 +25,6 @@ template<> inline int8_t   GETNA() { return NA_I1; }
 template<> inline int16_t  GETNA() { return NA_I2; }
 template<> inline int32_t  GETNA() { return NA_I4; }
 template<> inline int64_t  GETNA() { return NA_I8; }
-//template<> inline uint8_t  GETNA() { return NA_U1; }
-//template<> inline uint16_t GETNA() { return NA_U2; }
-//template<> inline uint32_t GETNA() { return NA_U4; }
-//template<> inline float    GETNA() { return NA_F4; }
-//template<> inline double   GETNA() { return NA_F8; }
 
 
 
@@ -57,7 +40,6 @@ class datacol_struct{
   wchar_t * stype;
   int datacoltype;
   int whichj;
-// const double * datacol = reinterpret_cast<const double**>(data)[j];
   datacol_struct(void **data, const wchar_t ** feature_stypes, int j):
             datacol_bool(reinterpret_cast<bool**>(data)[j]),
             datacol_int1(reinterpret_cast<int8_t**>(data)[j]),
@@ -96,21 +78,12 @@ class datacol_struct{
                     fwprintf(stderr,L"Unknown type %s", stype);
                     exit(1);
                 }
-//                fprintf(stderr,"chose datacoltype=%d for j=%d\n",datacoltype,j); fflush(stderr);
             };
-//  ~datacol_struct() {}
 };
 
 
-// map dt stype string to C ctype for casting purposes
-// {'i1b': 'bool', 'i1i': 'int', 'i2i': 'int', 'i4i': 'int', 'i8i': 'int', 'f4r': 'float', 'f8r': 'float'}
-
 bool dt_is_missing_and_get_value(datacol_struct *d, int i, float *value)
 {
-//    fprintf(stderr,"using1 datacoltype=%d for i=%d result=%g\n",d->datacoltype,i, d->datacol_double[i]); fflush(stderr);
-
-    // return false;
-    // fwprintf(stderr,L"stype = %s", stype);fflush(stderr);
     // order of likelihood
     switch(d->datacoltype){
         case 0:

--- a/src/c_api/dt.h
+++ b/src/c_api/dt.h
@@ -8,22 +8,22 @@
  * floating-point NAs require special functions `ISNA_F4(x)` and `ISNA_F8(x)`.
  */
 
-#define BIN_NAF4 0x7F8007A2u
-#define BIN_NAF8 0x7FF00000000007A2ull
-typedef union { uint64_t i; double d; } double_repr;
-typedef union { uint32_t i; float f; } float_repr;
-static inline float _nanf_(void) { float_repr x = { BIN_NAF4 }; return x.f; }
-static inline double _nand_(void) { double_repr x = { BIN_NAF8 }; return x.d; }
+//#define BIN_NAF4 0x7F8007A2u
+//#define BIN_NAF8 0x7FF00000000007A2ull
+//typedef union { uint64_t i; double d; } double_repr;
+//typedef union { uint32_t i; float f; } float_repr;
+//static inline float _nanf_(void) { float_repr x = { BIN_NAF4 }; return x.f; }
+//static inline double _nand_(void) { double_repr x = { BIN_NAF8 }; return x.d; }
 #define NA_I1  (-128)
 #define NA_I2  (-32768)
 #define NA_I4  (-2147483647-1)
 #define NA_I8  (-9223372036854775807-1)
-#define NA_U1  255u
-#define NA_U2  65535u
-#define NA_U4  4294967295u
-#define NA_U8  18446744073709551615u
-#define NA_F4  _nanf_()
-#define NA_F8  _nand_()
+//#define NA_U1  255u
+//#define NA_U2  65535u
+//#define NA_U4  4294967295u
+//#define NA_U8  18446744073709551615u
+//#define NA_F4  _nanf_()
+//#define NA_F8  _nand_()
 
 /**
  * GETNA function
@@ -36,8 +36,8 @@ template<> inline int8_t   GETNA() { return NA_I1; }
 template<> inline int16_t  GETNA() { return NA_I2; }
 template<> inline int32_t  GETNA() { return NA_I4; }
 template<> inline int64_t  GETNA() { return NA_I8; }
-template<> inline uint8_t  GETNA() { return NA_U1; }
-template<> inline uint16_t GETNA() { return NA_U2; }
-template<> inline uint32_t GETNA() { return NA_U4; }
-template<> inline float    GETNA() { return NA_F4; }
-template<> inline double   GETNA() { return NA_F8; }
+//template<> inline uint8_t  GETNA() { return NA_U1; }
+//template<> inline uint16_t GETNA() { return NA_U2; }
+//template<> inline uint32_t GETNA() { return NA_U4; }
+//template<> inline float    GETNA() { return NA_F4; }
+//template<> inline double   GETNA() { return NA_F8; }

--- a/src/c_api/dt.h
+++ b/src/c_api/dt.h
@@ -25,31 +25,6 @@ static inline double _nand_(void) { double_repr x = { BIN_NAF8 }; return x.d; }
 #define NA_F4  _nanf_()
 #define NA_F8  _nand_()
 
-
-#define NA_F4_BITS 0x7F8007A2u
-#define NA_F8_BITS 0x7FF00000000007A2ull
-extern const int8_t   NA_I1;
-extern const int16_t  NA_I2;
-extern const int32_t  NA_I4;
-extern const int64_t  NA_I8;
-extern const uint8_t  NA_U1;
-extern const uint16_t NA_U2;
-extern const uint32_t NA_U4;
-extern const uint64_t NA_U8;
-extern       float    NA_F4;
-extern       double   NA_F8;
-
-int ISNA_F4(float x);
-int ISNA_F8(double x);
-
-#define ISNA_I1(x)  ((int8_t)(x)   == NA_I1)
-#define ISNA_I2(x)  ((int16_t)(x)  == NA_I2)
-#define ISNA_I4(x)  ((int32_t)(x)  == NA_I4)
-#define ISNA_I8(x)  ((int64_t)(x)  == NA_I8)
-#define ISNA_U1(x)  ((uint8_t)(x)  == NA_U1)
-#define ISNA_U2(x)  ((uint16_t)(x) == NA_U2)
-#define ISNA_U4(x)  ((uint32_t)(x) == NA_U4)
-
 /**
  * GETNA function
  * Template function that returns the appropriate NA_XX value based on the
@@ -66,22 +41,3 @@ template<> inline uint16_t GETNA() { return NA_U2; }
 template<> inline uint32_t GETNA() { return NA_U4; }
 template<> inline float    GETNA() { return NA_F4; }
 template<> inline double   GETNA() { return NA_F8; }
-
-/**
- * ISNA function
- * Template function that uses the appropriate ISNA_XX macro/function based
- * on the argument type. Returns true if type is invalid.
- */
-template <typename T>
-inline bool ISNA(T)          { return true;       }
-template<> inline bool ISNA(int8_t x)   { return ISNA_I1(x); }
-template<> inline bool ISNA(int16_t x)  { return ISNA_I2(x); }
-template<> inline bool ISNA(int32_t x)  { return ISNA_I4(x); }
-template<> inline bool ISNA(int64_t x)  { return ISNA_I8(x); }
-template<> inline bool ISNA(uint8_t x)  { return ISNA_U1(x); }
-template<> inline bool ISNA(uint16_t x) { return ISNA_U2(x); }
-template<> inline bool ISNA(uint32_t x) { return ISNA_U4(x); }
-template<> inline bool ISNA(float x)    { return ISNA_F4(x); }
-template<> inline bool ISNA(double x)   { return ISNA_F8(x); }
-
-//==============================================================================

--- a/tests/benchmark/testdt.py
+++ b/tests/benchmark/testdt.py
@@ -28,45 +28,9 @@ def run_benchmark(args, gpu_algorithm, cpu_algorithm):
     param['tree_method'] = gpu_algorithm
 
     do_dt = True
+    do_ccont = False
     do_nondt = True
 
-    if do_dt:
-        tmp = time.time()
-        # convert to dt as test
-        X_train_cc = np.asfortranarray(X_train)
-        X_test_cc = np.asfortranarray(X_test)
-        y_train_cc = np.asfortranarray(y_train)
-        y_test_cc = np.asfortranarray(y_test)
-
-        if not (X_train_cc.flags['F_CONTIGUOUS'] and X_test_cc.flags['F_CONTIGUOUS']\
-            and y_train_cc.flags['F_CONTIGUOUS'] and y_test_cc.flags['F_CONTIGUOUS']):
-            ValueError("Need data to be Fortran (i.e. column-major) contiguous")
-
-
-        # convert to column-major contiguous in memory to mimic persistent column-major state
-        dtdata_X_train = dt.DataTable(X_train_cc)
-        dtdata_X_test = dt.DataTable(X_test_cc)
-        dtdata_y_train = dt.DataTable(y_train_cc)
-        dtdata_y_test = dt.DataTable(y_test_cc)
-
-        print ("dt prepare Time: %s seconds" % (str(time.time() - tmp)))
-
-        #test = dtdata_X_train[0:1].tonumpy()
-        #print(test)
-
-        print ("dt->DMatrix Start")
-        # omp way
-        tmp = time.time()
-        dtrain = xgb.DMatrix(dtdata_X_train, dtdata_y_train, nthread=-1)
-        print ("dt->DMatrix1 Time: %s seconds" % (str(time.time() - tmp)))
-        tmp = time.time()
-        dtest = xgb.DMatrix(dtdata_X_test, dtdata_y_test, nthread=-1)
-        print ("dt->DMatrix2 Time: %s seconds" % (str(time.time() - tmp)))
-
-        print("Training with '%s'" % param['tree_method'])
-        tmp = time.time()
-        xgb.train(param, dtrain, args.iterations, evals=[(dtest, "test")])
-        print ("Train Time: %s seconds" % (str(time.time() - tmp)))
     if do_nondt:
 
         print("np->DMatrix Start")
@@ -82,11 +46,55 @@ def run_benchmark(args, gpu_algorithm, cpu_algorithm):
         tmp = time.time()
         xgb.train(param, dtrain, args.iterations, evals=[(dtest, "test")])
         print("Train Time: %s seconds" % (str(time.time() - tmp)))
+    if do_dt:
+        tmp = time.time()
+        if do_ccont:
+            X_train_cc = X_train
+            X_test_cc = X_test
+            y_train_cc = y_train
+            y_test_cc = y_test
+        else:
+            # convert to dt as test
+            X_train_cc = np.asfortranarray(X_train)
+            X_test_cc = np.asfortranarray(X_test)
+            y_train_cc = np.asfortranarray(y_train)
+            y_test_cc = np.asfortranarray(y_test)
+    
+            if not (X_train_cc.flags['F_CONTIGUOUS'] and X_test_cc.flags['F_CONTIGUOUS']\
+                and y_train_cc.flags['F_CONTIGUOUS'] and y_test_cc.flags['F_CONTIGUOUS']):
+                ValueError("Need data to be Fortran (i.e. column-major) contiguous")
+
+        print ("dt prepare1 Time: %s seconds" % (str(time.time() - tmp)))
+
+        # convert to column-major contiguous in memory to mimic persistent column-major state
+        tmp = time.time()
+        dtdata_X_train = dt.DataTable(X_train_cc)
+        dtdata_X_test = dt.DataTable(X_test_cc)
+        dtdata_y_train = dt.DataTable(y_train_cc)
+        dtdata_y_test = dt.DataTable(y_test_cc)
+        print ("dt prepare2 Time: %s seconds" % (str(time.time() - tmp)))
+
+        #test = dtdata_X_train.tonumpy()
+        #print(test)
+
+        print ("dt->DMatrix Start")
+        # omp way
+        tmp = time.time()
+        dtrain = xgb.DMatrix(dtdata_X_train, dtdata_y_train, nthread=-1)
+        print ("dt->DMatrix1 Time: %s seconds" % (str(time.time() - tmp)))
+        tmp = time.time()
+        dtest = xgb.DMatrix(dtdata_X_test, dtdata_y_test, nthread=-1)
+        print ("dt->DMatrix2 Time: %s seconds" % (str(time.time() - tmp)))
+
+        print("Training with '%s'" % param['tree_method'])
+        tmp = time.time()
+        xgb.train(param, dtrain, args.iterations, evals=[(dtest, "test")])
+        print ("Train Time: %s seconds" % (str(time.time() - tmp)))
 
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--algorithm', choices=['all', 'gpu_exact', 'gpu_hist'], default='all')
-parser.add_argument('--rows', type=int, default=10000) # 1000000
+parser.add_argument('--rows', type=int, default=1000000) # 1000000
 parser.add_argument('--columns', type=int, default=50)
 parser.add_argument('--iterations', type=int, default=5) # 500
 parser.add_argument('--test_size', type=float, default=0.25)

--- a/tests/benchmark/testdt.py
+++ b/tests/benchmark/testdt.py
@@ -1,0 +1,70 @@
+# pylint: skip-file
+import sys, argparse
+import xgboost as xgb
+import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.model_selection import train_test_split
+import time
+import datatable as dt
+
+
+def run_benchmark(args, gpu_algorithm, cpu_algorithm):
+    print("Generating dataset: {} rows * {} columns".format(args.rows, args.columns))
+    print("{}/{} test/train split".format(args.test_size, 1.0 - args.test_size))
+    tmp = time.time()
+    X, y = make_classification(args.rows, n_features=args.columns, random_state=7)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=args.test_size, random_state=7)
+    print ("Generate Time: %s seconds" % (str(time.time() - tmp)))
+    tmp = time.time()
+
+    # convert to dt as test
+    dtdata_X_train = dt.DataTable(X_train)
+    dtdata_X_test = dt.DataTable(X_test)
+    dtdata_y_train = dt.DataTable(y_train)
+    dtdata_y_test = dt.DataTable(y_test)
+
+    return
+    print ("DMatrix Start")
+    # omp way
+    dtrain = xgb.DMatrix(X_train, y_train, nthread=-1)
+    dtest = xgb.DMatrix(X_test, y_test, nthread=-1)
+    print ("DMatrix Time: %s seconds" % (str(time.time() - tmp)))
+
+    param = {'objective': 'binary:logistic',
+             'max_depth': 6,
+             'silent': 0,
+             'n_gpus': 1,
+             'gpu_id': 0,
+             'eval_metric': 'error',
+             'debug_verbose': 0,
+             }
+
+    param['tree_method'] = gpu_algorithm
+    print("Training with '%s'" % param['tree_method'])
+    tmp = time.time()
+    xgb.train(param, dtrain, args.iterations, evals=[(dtest, "test")])
+    print ("Train Time: %s seconds" % (str(time.time() - tmp)))
+
+    param['silent'] = 1
+    param['tree_method'] = cpu_algorithm
+    print("Training with '%s'" % param['tree_method'])
+    tmp = time.time()
+    xgb.train(param, dtrain, args.iterations, evals=[(dtest, "test")])
+    print ("Time: %s seconds" % (str(time.time() - tmp)))
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--algorithm', choices=['all', 'gpu_exact', 'gpu_hist'], default='all')
+parser.add_argument('--rows', type=int, default=10000) # 1000000
+parser.add_argument('--columns', type=int, default=50)
+parser.add_argument('--iterations', type=int, default=5) # 500
+parser.add_argument('--test_size', type=float, default=0.25)
+args = parser.parse_args()
+
+if 'gpu_hist' in args.algorithm:
+    run_benchmark(args, args.algorithm, 'hist')
+elif 'gpu_exact' in args.algorithm:
+    run_benchmark(args, args.algorithm, 'exact')
+elif 'all' in args.algorithm:
+    run_benchmark(args, 'gpu_exact', 'exact')
+    run_benchmark(args, 'gpu_hist', 'hist')

--- a/tests/benchmark/testdt.py
+++ b/tests/benchmark/testdt.py
@@ -28,7 +28,7 @@ def run_benchmark(args, gpu_algorithm, cpu_algorithm):
     param['tree_method'] = gpu_algorithm
 
     do_dt = True
-    do_ccont = False
+    do_ccont = True
     do_nondt = True
 
     tmp = time.time()

--- a/tests/benchmark/testdt.py
+++ b/tests/benchmark/testdt.py
@@ -21,6 +21,11 @@ def run_benchmark(args, gpu_algorithm, cpu_algorithm):
     print("{}/{} test/train split".format(args.test_size, 1.0 - args.test_size))
     tmp = time.time()
     X, y = make_classification(args.rows, n_features=args.columns, random_state=7)
+    aa = np.random.rand(X.shape[0],X.shape[1])
+    fraction_missing = 0.1
+    X[aa<fraction_missing]=np.NaN
+    print("Number of Nans: %d" % (np.isnan(X).sum()))
+
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=args.test_size, random_state=7)
     print ("Generate Time: %s seconds" % (str(time.time() - tmp)))
 

--- a/tests/benchmark/testdt.py
+++ b/tests/benchmark/testdt.py
@@ -36,8 +36,8 @@ def run_benchmark(args, gpu_algorithm, cpu_algorithm):
     param['tree_method'] = gpu_algorithm
 
     do_dt = True
-    do_ccont = True
-    do_nondt = False # True
+    do_ccont = False
+    do_nondt = True
 
     tmp = time.time()
     if do_ccont:

--- a/tests/benchmark/testdt.py
+++ b/tests/benchmark/testdt.py
@@ -37,7 +37,7 @@ def run_benchmark(args, gpu_algorithm, cpu_algorithm):
 
     do_dt = True
     do_ccont = True
-    do_nondt = True
+    do_nondt = False # True
 
     tmp = time.time()
     if do_ccont:

--- a/tests/benchmark/testdt.py
+++ b/tests/benchmark/testdt.py
@@ -18,10 +18,24 @@ def run_benchmark(args, gpu_algorithm, cpu_algorithm):
     tmp = time.time()
 
     # convert to dt as test
-    dtdata_X_train = dt.DataTable(X_train)
-    dtdata_X_test = dt.DataTable(X_test)
-    dtdata_y_train = dt.DataTable(y_train)
-    dtdata_y_test = dt.DataTable(y_test)
+    X_train_cc = np.asfortranarray(X_train)
+    X_test_cc = np.asfortranarray(X_test)
+    y_train_cc = np.asfortranarray(y_train)
+    y_test_cc = np.asfortranarray(y_test)
+
+    if not (X_train_cc.flags['F_CONTIGUOUS'] and X_test_cc.flags['F_CONTIGUOUS']\
+        and y_train_cc.flags['F_CONTIGUOUS'] and y_test_cc.flags['F_CONTIGUOUS']):
+        ValueError("Need data to be Fortran (i.e. column-major) contiguous")
+
+
+    # convert to column-major contiguous in memory
+    dtdata_X_train = dt.DataTable(X_train_cc)
+    dtdata_X_test = dt.DataTable(X_test_cc)
+    dtdata_y_train = dt.DataTable(y_train_cc)
+    dtdata_y_test = dt.DataTable(y_test_cc)
+    
+    #test = dtdata_X_train[0:1].tonumpy()
+    #print(test)
 
     print ("DMatrix Start")
     # omp way

--- a/tests/benchmark/testdt.py
+++ b/tests/benchmark/testdt.py
@@ -23,11 +23,10 @@ def run_benchmark(args, gpu_algorithm, cpu_algorithm):
     dtdata_y_train = dt.DataTable(y_train)
     dtdata_y_test = dt.DataTable(y_test)
 
-    return
     print ("DMatrix Start")
     # omp way
-    dtrain = xgb.DMatrix(X_train, y_train, nthread=-1)
-    dtest = xgb.DMatrix(X_test, y_test, nthread=-1)
+    dtrain = xgb.DMatrix(dtdata_X_train, dtdata_y_train, nthread=-1)
+    dtest = xgb.DMatrix(dtdata_X_test, dtdata_y_test, nthread=-1)
     print ("DMatrix Time: %s seconds" % (str(time.time() - tmp)))
 
     param = {'objective': 'binary:logistic',


### PR DESCRIPTION
Anything non-optimal here?

To try it, do:
cd build ; cmake .. -DUSE_CUDA=ON -DGPU_COMPUTE_VER="61"  ; make -j ; cd ../python-package ; python setup.py install ; cd .. ; python tests/benchmark/testdt.py --algorithm=gpu_hist

Should do both numpy and dt versions and one can compare the time for DMatrix1 (train) and DMatrix2 (test) matrices.  Should be very similar, so not performance loss compared to inputting column-major or row-major numpy.  You can change do_ccont = False to True to have numpy as column-major.

I'll remove debug stuff once I'm happy and you guys comment.