### PR TITLE
Added "mojo" format for dumping models

### DIFF
--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -111,6 +111,23 @@ struct GBTreeModel {
   std::vector<std::string> DumpModel(const FeatureMap& fmap, bool with_stats,
                                      std::string format) const {
     std::vector<std::string> dump;
+    if (format == "mojo") {
+      std::stringstream fo("");
+      fo.precision(20);
+      fo << "Version 0.1.0\n"
+         << "num_output_group: " << param.num_output_group << "\n"
+         << "base_margin: " << base_margin << "\n";
+      if (param.num_output_group > 1) {
+        fo << "tree_info: [";
+        for (size_t i = 0; i < tree_info.size(); ++i) {
+          if (i != 0) fo << ",";
+          fo << tree_info[i];
+        }
+        fo << "]\n";
+      }
+      fo << "\n";
+      dump.push_back(fo.str());
+    }
     for (size_t i = 0; i < trees.size(); i++) {
       dump.push_back(trees[i]->DumpModel(fmap, with_stats, format));
     }

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -72,6 +72,11 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
                << ", \"yes\": " << tree[nid].cleft()
                << ", \"no\": " << tree[nid].cright()
                << ", \"missing\": " << tree[nid].cdefault();
+          } else if (format == "mojo") {
+            fo << nid << ":[" << fmap.name(split_index) << "<" << cond
+               << "] yes=" << tree[nid].cleft()
+               << ",no=" << tree[nid].cright()
+               << ",missing=" << tree[nid].cdefault();
           } else {
             fo << nid << ":[" << fmap.name(split_index) << "<"
                << int(cond + 1.0)
@@ -144,7 +149,8 @@ std::string RegTree::DumpModel(const FeatureMap& fmap,
                                bool with_stats,
                                std::string format) const {
   std::stringstream fo("");
-  fo.precision(20);
+  if (format == "mojo")
+    fo.precision(20);
   for (int i = 0; i < param.num_roots; ++i) {
     DumpRegTree(fo, *this, fmap, i, 0, false, with_stats, format);
   }


### PR DESCRIPTION
The "mojo" format for `DumpModel` will add additional model information, increase precision when writing `float`s, and refrain from converting `float`s to `int`s for certain features.
The default model dump's `float` precision is reverted to its original value of 6.