### PR TITLE
Booster doesn't require Kryo

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -75,9 +75,14 @@ public class Booster implements Serializable {
   }
 
   protected Booster(Map<String, Object> params, DMatrix[] cacheMats, boolean isKryoBooster) throws XGBoostError {
+    this(isKryoBooster);
     init(cacheMats);
     setParam("seed", "0");
     setParams(params);
+  }
+
+  // Booster is not actually initialized in this constructor; must be initialized later - used in deserialization
+  protected Booster(boolean isKryoBooster) {
     if (USE_KRYO_BOOSTER != isKryoBooster)
       throw new IllegalStateException("Attempt to instantiate a Booster without support for Kryo in an environment that supports Kryo.");
   }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/KryoBooster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/KryoBooster.java
@@ -1,0 +1,50 @@
+package ml.dmlc.xgboost4j.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.Map;
+
+@SuppressWarnings("unused")
+public class KryoBooster extends Booster implements KryoSerializable {
+
+  private static final Log logger = LogFactory.getLog(KryoBooster.class);
+
+  KryoBooster(Map<String, Object> params, DMatrix[] cacheMats) throws XGBoostError {
+    super(params, cacheMats, true);
+  }
+
+  @Override
+  public void write(Kryo kryo, Output output) {
+    try {
+      byte[] serObj = this.toByteArray();
+      int serObjSize = serObj.length;
+      System.out.println("==== serialized obj size " + serObjSize);
+      output.writeInt(serObjSize);
+      output.write(serObj);
+    } catch (XGBoostError ex) {
+      ex.printStackTrace();
+      logger.error(ex.getMessage());
+    }
+  }
+
+  @Override
+  public void read(Kryo kryo, Input input) {
+    try {
+      int serObjSize = input.readInt();
+      System.out.println("==== the size of the object: " + serObjSize);
+      byte[] bytes = new byte[serObjSize];
+      input.readBytes(bytes);
+      initFromBytes(bytes);
+    } catch (XGBoostError ex) {
+      ex.printStackTrace();
+      logger.error(ex.getMessage());
+    }
+  }
+
+
+}

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/KryoBooster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/KryoBooster.java
@@ -1,3 +1,18 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 package ml.dmlc.xgboost4j.java;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -18,33 +33,35 @@ public class KryoBooster extends Booster implements KryoSerializable {
     super(params, cacheMats, true);
   }
 
+  KryoBooster() {
+    super(true);
+  }
+
   @Override
   public void write(Kryo kryo, Output output) {
+    byte[] serObj;
     try {
-      byte[] serObj = this.toByteArray();
-      int serObjSize = serObj.length;
-      System.out.println("==== serialized obj size " + serObjSize);
-      output.writeInt(serObjSize);
-      output.write(serObj);
+      serObj = this.toByteArray();
     } catch (XGBoostError ex) {
-      ex.printStackTrace();
-      logger.error(ex.getMessage());
+      throw new RuntimeException("Booster serialization failed", ex);
     }
+    int serObjSize = serObj.length;
+    logger.debug("==== serialized obj size " + serObjSize);
+    output.writeInt(serObjSize);
+    output.write(serObj);
   }
 
   @Override
   public void read(Kryo kryo, Input input) {
+    int serObjSize = input.readInt();
+    logger.debug("==== the size of the object: " + serObjSize);
+    byte[] bytes = new byte[serObjSize];
+    input.readBytes(bytes);
     try {
-      int serObjSize = input.readInt();
-      System.out.println("==== the size of the object: " + serObjSize);
-      byte[] bytes = new byte[serObjSize];
-      input.readBytes(bytes);
       initFromBytes(bytes);
     } catch (XGBoostError ex) {
-      ex.printStackTrace();
-      logger.error(ex.getMessage());
+      throw new RuntimeException("Booster deserialization failed", ex);
     }
   }
-
 
 }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -104,7 +104,7 @@ public class XGBoost {
     }
 
     //initialize booster
-    Booster booster = new Booster(params, allMats);
+    Booster booster = Booster.newBooster(params, allMats);
 
     int version = booster.loadRabitCheckpoint();
 
@@ -318,7 +318,7 @@ public class XGBoost {
     public CVPack(DMatrix dtrain, DMatrix dtest, Map<String, Object> params)
             throws XGBoostError {
       dmats = new DMatrix[]{dtrain, dtest};
-      booster = new Booster(params, dmats);
+      booster = Booster.newBooster(params, dmats);
       names = new String[]{"train", "test"};
       this.dtrain = dtrain;
       this.dtest = dtest;


### PR DESCRIPTION
Booster is dynamically created with KryoSupport if Kryo libraries are
present on classpath. This lets the users to optionally exclude Kryo
and create deployment packages that will work both with and without Kryo.