### PR TITLE
Visitor interface for Xgb models.

### DIFF
--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -18,6 +18,7 @@
 #include "./data.h"
 #include "./objective.h"
 #include "./feature_map.h"
+#include "./model_visitor.h"
 #include "../../src/common/host_device_vector.h"
 
 namespace xgboost {
@@ -140,6 +141,13 @@ class GradientBooster {
   virtual std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                              bool with_stats,
                                              std::string format) const = 0;
+
+  /*!
+   * \brief Allow model access via visitor interface.
+   * \param v  visitor for this class
+   */
+  virtual void Accept(ModelVisitor& v) = 0;
+
   /*!
    * \brief create a gradient booster from given name
    * \param name name of gradient booster

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -16,8 +16,10 @@
 #include "./gbm.h"
 #include "./metric.h"
 #include "./objective.h"
+#include "./model_visitor.h"
 
 namespace xgboost {
+
 /*!
  * \brief Learner class that does training and prediction.
  *  This is the user facing module of xgboost training.
@@ -177,6 +179,12 @@ class Learner : public rabit::Serializable {
    * \return Created learner.
    */
   static Learner* Create(const std::vector<std::shared_ptr<DMatrix> >& cache_data);
+
+  /*!
+   * \brief Allow model access via visitor interface.
+   * \param v  visitor for this class
+   */
+  void Accept(ModelVisitor& v);
 
  protected:
   /*! \brief internal base score of the model */

--- a/include/xgboost/model_visitor.h
+++ b/include/xgboost/model_visitor.h
@@ -1,0 +1,40 @@
+/*!
+ * Copyright 2018 by Contributors
+ * \file model_visitor.h
+ * \brief a generic model visitor interface
+ */
+#ifndef XGBOOST_MODEL_VISITOR_H_
+#define XGBOOST_MODEL_VISITOR_H_
+
+namespace xgboost {
+
+template<typename T>
+class Visitor {
+    public:
+        virtual void Visit(T& t) {
+            // noop
+        }
+};
+
+// Forward definitions
+class Learner;
+class GradientBooster;
+namespace gbm {
+	class GBTreeModel;
+    class GBLinearModel;
+}
+
+class ModelVisitor : public Visitor<Learner>,
+                   public Visitor<GradientBooster>,
+                   public Visitor<gbm::GBTreeModel>,
+                   public Visitor<gbm::GBLinearModel> {
+  public:
+	using Visitor<Learner>::Visit;
+	using Visitor<GradientBooster>::Visit;
+	using Visitor<gbm::GBTreeModel>::Visit;
+	using Visitor<gbm::GBLinearModel>::Visit;
+};
+
+} // namespace xgboost
+
+#endif

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -10,6 +10,7 @@
 #include <xgboost/gbm.h>
 #include <xgboost/logging.h>
 #include <xgboost/linear_updater.h>
+#include <xgboost/model_visitor.h>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -193,6 +194,12 @@ class GBLinear : public GradientBooster {
                                      bool with_stats,
                                      std::string format) const override {
     return model_.DumpModel(fmap, with_stats, format);
+  }
+
+  void Accept(ModelVisitor& v) override {
+    v.Visit(*this);
+    // This is forcing visit of model which is inherent part of this object
+    model_.Accept(v);
   }
 
  protected:

--- a/src/gbm/gblinear_model.h
+++ b/src/gbm/gblinear_model.h
@@ -5,6 +5,7 @@
 #include <dmlc/io.h>
 #include <dmlc/parameter.h>
 #include <xgboost/feature_map.h>
+#include <xgboost/model_visitor.h>
 #include <vector>
 #include <string>
 #include <cstring>
@@ -107,6 +108,10 @@ class GBLinearModel {
     std::vector<std::string> v;
     v.push_back(fo.str());
     return v;
+  }
+
+  void Accept(ModelVisitor& v) {
+      v.Visit(*this);
   }
 };
 }  // namespace gbm

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -255,6 +255,11 @@ class GBTree : public GradientBooster {
     return model_.DumpModel(fmap, with_stats, format);
   }
 
+  void Accept(ModelVisitor& v) override {
+    v.Visit(*this);
+    model_.Accept(v);
+  }
+
  protected:
   // initialize updater before using them
   inline void InitUpdater() {

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -5,6 +5,7 @@
 #include <dmlc/parameter.h>
 #include <dmlc/io.h>
 #include <xgboost/tree_model.h>
+#include <xgboost/model_visitor.h>
 #include <utility>
 #include <string>
 #include <vector>
@@ -140,6 +141,10 @@ struct GBTreeModel {
       tree_info.push_back(bst_group);
     }
     param.num_trees += static_cast<int>(new_trees.size());
+  }
+
+  void Accept(ModelVisitor &v) {
+      v.Visit(*this);
   }
 
   // base margin

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -34,6 +34,12 @@ std::vector<std::string> Learner::DumpModel(const FeatureMap& fmap,
   return gbm_->DumpModel(fmap, with_stats, format);
 }
 
+void Learner::Accept(ModelVisitor& v) {
+  v.Visit(*this);
+  // Also visit the booster
+  gbm_->Accept(v);
+}
+
 /*! \brief training parameter for regression */
 struct LearnerModelParam : public dmlc::Parameter<LearnerModelParam> {
   /* \brief global bias */


### PR DESCRIPTION
The visitor allows introspection of publicly available
classes Learner, GradientBooster, GBTreeModel, GBLinearModel.

This will enable:
  - adhoc serialization
  - easy trees introspection (CC: @Far0n )