### PR TITLE
PUBDEV-5612 - Crash on Tesla V100 - attempt to build against its arch…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ lib/
 metastore_db
 
 plugin/updater_gpu/test/cpp/data
+demo/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ set_default_configuration_release()
 msvc_use_static_runtime()
 
 # Options
-option(USE_CUDA  "Build with GPU acceleration") 
+option(USE_CUDA  "Build with GPU acceleration")
 option(JVM_BINDINGS "Build JVM bindings" OFF)
 option(GOOGLE_TEST "Build google tests" OFF)
 option(R_LIB "Build shared library for R package" OFF)
 option(USE_OPENMP "Build with OMP support" ON)
-set(GPU_COMPUTE_VER 35;50;52;60;61 CACHE STRING
-  "Space separated list of compute versions to be built against")
+set(GPU_COMPUTE_VER "" CACHE STRING
+"Space separated list of compute versions to be built against, e.g. '35 61'")
 
 # Use OpenMP
 if(USE_OPENMP)
@@ -60,7 +60,7 @@ include_directories (
     ${PROJECT_SOURCE_DIR}/rabit/include
 )
 
-file(GLOB_RECURSE SOURCES 
+file(GLOB_RECURSE SOURCES
     src/*.cc
     src/*.h
     include/*.h
@@ -104,7 +104,7 @@ if(USE_CUDA)
   cmake_minimum_required(VERSION 3.5)
 
   add_definitions(-DXGBOOST_USE_CUDA)
-  
+
   include_directories(
     nccl/src
     cub
@@ -112,15 +112,16 @@ if(USE_CUDA)
 
   set(GENCODE_FLAGS "")
   format_gencode_flags("${GPU_COMPUTE_VER}" GENCODE_FLAGS)
+  message("cuda architecture flags: ${GENCODE_FLAGS}")
   set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};--expt-extended-lambda;${GENCODE_FLAGS};-lineinfo;")
   if(NOT MSVC)
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler -fPIC; -std=c++11")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler -fPIC; -Xcompiler -Werror; -std=c++11")
   endif()
 
   add_subdirectory(nccl)
   cuda_add_library(gpuxgboost ${CUDA_SOURCES} STATIC)
   target_link_libraries(gpuxgboost nccl)
-  list(APPEND LINK_LIBRARIES gpuxgboost) 
+  list(APPEND LINK_LIBRARIES gpuxgboost)
 endif()
 
 

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -54,10 +54,25 @@ function(set_default_configuration_release)
 	endif()
 endfunction(set_default_configuration_release)
 
-function(format_gencode_flags flags out)
-  foreach(ver ${flags})
-    set(${out} "${${out}}-gencode arch=compute_${ver},code=sm_${ver};")
-  endforeach()
+# Generate nvcc compiler flags given a list of architectures
+# Also generates PTX for the most recent architecture for forwards compatibility
+ function(format_gencode_flags flags out)
+  # Set up architecture flags
+  if(NOT flags)
+    if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
+      set(flags "35;50;52;60;61;70")
+    else()
+      set(flags "35;50;52;60;61")
+    endif()
+  endif()
+  # Generate SASS
+   foreach(ver ${flags})
+     set(${out} "${${out}}-gencode=arch=compute_${ver},code=sm_${ver};")
+   endforeach()
+  # Generate PTX for last architecture
+  list(GET flags -1 ver)
+  set(${out} "${${out}}-gencode=arch=compute_${ver},code=compute_${ver};")
+
   set(${out} "${${out}}" PARENT_SCOPE)
 endfunction(format_gencode_flags flags)
 

--- a/tests/cpp/common/test_device_helpers.cu
+++ b/tests/cpp/common/test_device_helpers.cu
@@ -24,29 +24,6 @@ void CreateTestData(xgboost::bst_uint num_rows, int max_row_size,
   }
 }
 
-void SpeedTest() {
-  int num_rows = 1000000;
-  int max_row_size = 100;
-  dh::CubMemory temp_memory;
-  thrust::host_vector<int> h_row_ptr;
-  thrust::host_vector<xgboost::bst_uint> h_rows;
-  CreateTestData(num_rows, max_row_size, &h_row_ptr, &h_rows);
-  thrust::device_vector<int> row_ptr = h_row_ptr;
-  thrust::device_vector<int> output_row(h_rows.size());
-  auto d_output_row = output_row.data();
-
-  dh::Timer t;
-  dh::TransformLbs(
-      0, &temp_memory, h_rows.size(), dh::raw(row_ptr), row_ptr.size() - 1, false,
-      [=] __device__(size_t idx, size_t ridx) { d_output_row[idx] = ridx; });
-
-  dh::safe_cuda(cudaDeviceSynchronize());
-  double time = t.ElapsedSeconds();
-  const int mb_size = 1048576;
-  size_t size = (sizeof(int) * h_rows.size()) / mb_size;
-  printf("size: %llumb, time: %fs, bandwidth: %fmb/s\n", size, time,
-         size / time);
-}
 
 void TestLbs() {
   srand(17);


### PR DESCRIPTION
…itecture

A port of this commit by @RAMitchell to H2O3 branch: https://github.com/dmlc/xgboost/pull/3316

Only the `set(${out} "${${out}}-gencode=arch=compute_${ver},code=sm_${ver};")` uses `=` char between `-gencode` and `arch`, instead of a blank space in the original document. Should not affect performance probably, but Nvidia advises this syntax in their [compatibility guide](https://docs.nvidia.com/cuda/volta-compatibility-guide/index.html#verifying-volta-compatibility-using-cuda-8-0).