### PR TITLE
MOJO compatibility with GBLinear 

### DIFF
--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -53,6 +53,8 @@ class GBLinear : public GradientBooster {
   explicit GBLinear(const std::vector<std::shared_ptr<DMatrix> > &cache,
                     bst_float base_margin)
       : base_margin_(base_margin),
+        model_(base_margin),
+        previous_model_(base_margin),
         sum_instance_weight_(0),
         sum_weight_complete_(false),
         is_converged_(false) {

--- a/src/gbm/gblinear_model.h
+++ b/src/gbm/gblinear_model.h
@@ -36,10 +36,12 @@ struct GBLinearModelParam : public dmlc::Parameter<GBLinearModelParam> {
 // model for linear booster
 class GBLinearModel {
  public:
+  explicit GBLinearModel(bst_float base_margin) : base_margin(base_margin) {}
   // parameter
   GBLinearModelParam param;
   // weight for each of feature, bias is the last one
   std::vector<bst_float> weight;
+  bst_float base_margin;
   // initialize the model parameter
   inline void LazyInitModel() {
     if (!weight.empty()) return;


### PR DESCRIPTION
Made a redundant `base_margin` field in `GBLinearModel` that in only used when marshaling the model for MOJO.