### PR TITLE
Adds new way of defining DMatrix using off-heap memory populated in Java

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -214,7 +214,7 @@ public class DMatrix {
    */
   public DMatrix(BigDenseMatrix matrix, float missing) throws XGBoostError {
     long[] out = new long[1];
-    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromMatRef(matrix.address, (int) matrix.nrow, (int) matrix.ncol, missing, out));
+    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromMatRef(matrix.address, matrix.nrow, matrix.ncol, missing, out));
     handle = out[0];
   }
 

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -16,7 +16,7 @@
 package ml.dmlc.xgboost4j.java;
 
 import java.util.Iterator;
-
+import ml.dmlc.xgboost4j.java.util.BigDenseMatrix;
 import ml.dmlc.xgboost4j.LabeledPoint;
 
 /**
@@ -185,6 +185,16 @@ public class DMatrix {
   }
 
   /**
+   * create DMatrix from a BigDenseMatrix
+   *
+   * @param matrix instance of BigDenseMatrix
+   * @throws XGBoostError native error
+   */
+  public DMatrix(BigDenseMatrix matrix) throws XGBoostError {
+    this(matrix, 0.0f);
+  }
+
+  /**
    * create DMatrix from dense matrix
    * @param data data values
    * @param nrow number of rows
@@ -194,6 +204,17 @@ public class DMatrix {
   public DMatrix(float[] data, int nrow, int ncol, float missing) throws XGBoostError {
     long[] out = new long[1];
     XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromMat(data, nrow, ncol, missing, out));
+    handle = out[0];
+  }
+
+  /**
+   * create DMatrix from dense matrix
+   * @param matrix instance of BigDenseMatrix
+   * @param missing the specified value to represent the missing value
+   */
+  public DMatrix(BigDenseMatrix matrix, float missing) throws XGBoostError {
+    long[] out = new long[1];
+    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromMatRef(matrix.address, (int) matrix.nrow, (int) matrix.ncol, missing, out));
     handle = out[0];
   }
 

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -71,6 +71,9 @@ class XGBoostJNI {
   public final static native int XGDMatrixCreateFromMat(float[] data, int nrow, int ncol,
                                                         float missing, long[] out);
 
+  public final static native int XGDMatrixCreateFromMatRef(long dataRef, int nrow, int ncol,
+                                                           float missing, long[] out);
+
   public final static native int XGDMatrixCreateFrom2DMat(float[][] data, long nrow, int ncol,
                                                         float missing, long[] out);
 

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrix.java
@@ -22,29 +22,29 @@ public final class BigDenseMatrix {
 
   private final static int FLOAT_BYTE_SIZE = 4;
 
-  public final long nrow;
-  public final long ncol;
+  public final int nrow;
+  public final int ncol;
   public final long address;
 
-  public BigDenseMatrix(long nrow, long ncol) {
+  public BigDenseMatrix(int nrow, int ncol) {
     this.nrow = nrow;
     this.ncol = ncol;
     this.address = UtilUnsafe.UNSAFE.allocateMemory(ncol * nrow * FLOAT_BYTE_SIZE);
   }
 
-  public final void set(long idx, float val) {
+  public final void set(int idx, float val) {
     UtilUnsafe.UNSAFE.putFloat(address + idx * FLOAT_BYTE_SIZE, val);
   }
 
-  public final void set(long i, long j, float val) {
+  public final void set(int i, int j, float val) {
     set(i * ncol + j, val);
   }
 
-  public final float get(long idx) {
+  public final float get(int idx) {
     return UtilUnsafe.UNSAFE.getFloat(address + idx * FLOAT_BYTE_SIZE);
   }
 
-  public final float get(long i, long j) {
+  public final float get(int i, int j) {
     return get(i * ncol + j);
   }
 

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrix.java
@@ -1,0 +1,55 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package ml.dmlc.xgboost4j.java.util;
+
+/**
+ * Off-heap implementation of a Dense Matrix, matrix size is only limited by the amount of the available memory
+ */
+public final class BigDenseMatrix {
+
+  private final static int FLOAT_BYTE_SIZE = 4;
+
+  public final long nrow;
+  public final long ncol;
+  public final long address;
+
+  public BigDenseMatrix(long nrow, long ncol) {
+    this.nrow = nrow;
+    this.ncol = ncol;
+    this.address = UtilUnsafe.UNSAFE.allocateMemory(ncol * nrow * FLOAT_BYTE_SIZE);
+  }
+
+  public final void set(long idx, float val) {
+    UtilUnsafe.UNSAFE.putFloat(address + idx * FLOAT_BYTE_SIZE, val);
+  }
+
+  public final void set(long i, long j, float val) {
+    set(i * ncol + j, val);
+  }
+
+  public final float get(long idx) {
+    return UtilUnsafe.UNSAFE.getFloat(address + idx * FLOAT_BYTE_SIZE);
+  }
+
+  public final float get(long i, long j) {
+    return get(i * ncol + j);
+  }
+
+  public final void dispose() {
+    UtilUnsafe.UNSAFE.freeMemory(address);
+  }
+
+}

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrix.java
@@ -16,20 +16,26 @@
 package ml.dmlc.xgboost4j.java.util;
 
 /**
- * Off-heap implementation of a Dense Matrix, matrix size is only limited by the amount of the available memory
+ * Off-heap implementation of a Dense Matrix, matrix size is only limited by the amount of the available memory and
+ * the matrix dimension cannot exceed Integer.MAX_VALUE (this is consistent with XGBoost API restrictions on maximum
+ * length of a response).
  */
 public final class BigDenseMatrix {
 
   private final static int FLOAT_BYTE_SIZE = 4;
+  public static final long MAX_MATRIX_SIZE = Long.MAX_VALUE / FLOAT_BYTE_SIZE;
 
   public final int nrow;
   public final int ncol;
   public final long address;
 
   public BigDenseMatrix(int nrow, int ncol) {
+    final long size = (long) nrow * ncol;
+    if (size > MAX_MATRIX_SIZE)
+      throw new IllegalArgumentException("Matrix too large; matrix size cannot exceed " + MAX_MATRIX_SIZE);
     this.nrow = nrow;
     this.ncol = ncol;
-    this.address = UtilUnsafe.UNSAFE.allocateMemory(ncol * nrow * FLOAT_BYTE_SIZE);
+    this.address = UtilUnsafe.UNSAFE.allocateMemory(size * FLOAT_BYTE_SIZE);
   }
 
   public final void set(int idx, float val) {

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/util/UtilUnsafe.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/util/UtilUnsafe.java
@@ -1,0 +1,44 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package ml.dmlc.xgboost4j.java.util;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+
+/**
+ * Simple class to obtain access to the {@link Unsafe} object. Use responsibly :)
+ */
+public final class UtilUnsafe {
+
+  static Unsafe UNSAFE = getUnsafe();
+
+  private UtilUnsafe() { } // dummy private constructor
+
+  private static Unsafe getUnsafe() {
+    // Not on bootclasspath
+    if( UtilUnsafe.class.getClassLoader() == null )
+      return Unsafe.getUnsafe();
+    try {
+      final Field fld = Unsafe.class.getDeclaredField("theUnsafe");
+      fld.setAccessible(true);
+      return (Unsafe) fld.get(UtilUnsafe.class);
+    } catch (Exception e) {
+      throw new RuntimeException("Could not obtain access to sun.misc.Unsafe", e);
+    }
+  }
+
+}

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -345,10 +345,10 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixCreateFromMatRef
- * Signature: (JJJF)J
+ * Signature: (JIIF)J
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromMatRef
-  (JNIEnv *jenv, jclass jcls, jlong jdataRef, jlong jnrow, jlong jncol, jfloat jmiss, jlongArray jout) {
+  (JNIEnv *jenv, jclass jcls, jlong jdataRef, jint jnrow, jint jncol, jfloat jmiss, jlongArray jout) {
   DMatrixHandle result;
   bst_ulong nrow = (bst_ulong)jnrow;
   bst_ulong ncol = (bst_ulong)jncol;

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -344,6 +344,22 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixCreateFromMatRef
+ * Signature: (JJJF)J
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromMatRef
+  (JNIEnv *jenv, jclass jcls, jlong jdataRef, jlong jnrow, jlong jncol, jfloat jmiss, jlongArray jout) {
+  DMatrixHandle result;
+  bst_ulong nrow = (bst_ulong)jnrow;
+  bst_ulong ncol = (bst_ulong)jncol;
+  jint ret = (jint) XGDMatrixCreateFromMat((float const *)jdataRef, nrow, ncol, jmiss, &result);
+  setHandle(jenv, jout, result);
+  return ret;
+}
+
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixCreateFromMat
  * Signature: ([FIIF)J
  */
@@ -359,6 +375,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   jenv->ReleaseFloatArrayElements(jdata, data, 0);
   return ret;
 }
+
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -74,10 +74,10 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixCreateFromMatRef
- * Signature: (JJJF[J)I
+ * Signature: (JIIF[J)I
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromMatRef
-  (JNIEnv *jenv, jclass jcls, jlong jdataRef, jlong jnrow, jlong jncol, jfloat jmiss, jlongArray jout);
+  (JNIEnv *jenv, jclass jcls, jlong jdataRef, jint jnrow, jint jncol, jfloat jmiss, jlongArray jout);
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -47,7 +47,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFrom2DCSREx
   (JNIEnv *, jclass, jobjectArray, jobjectArray, jobjectArray, jint, jint, jlong, jlongArray);
 
-
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixCreateFromCSCEx
@@ -74,12 +73,19 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixCreateFromMatRef
+ * Signature: (JJJF[J)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromMatRef
+  (JNIEnv *jenv, jclass jcls, jlong jdataRef, jlong jnrow, jlong jncol, jfloat jmiss, jlongArray jout);
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixCreateFrom2DMat
  * Signature: ([FIIF[J)I
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFrom2DMat
   (JNIEnv *, jclass, jobjectArray, jlong, jint, jfloat, jlongArray);
-
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
@@ -16,10 +16,14 @@
 package ml.dmlc.xgboost4j.java;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
 import junit.framework.TestCase;
+import ml.dmlc.xgboost4j.java.util.BigDenseMatrix;
 import ml.dmlc.xgboost4j.LabeledPoint;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -223,4 +227,98 @@ public class DMatrixTest {
     TestCase.assertTrue(dmat0.rowNum() == 10);
     TestCase.assertTrue(dmat0.getLabel().length == 10);
   }
+
+  @Test
+  public void testCreateFromDenseMatrixRef() throws XGBoostError {
+    //create DMatrix from 10*5 dense matrix
+    final int nrow = 10;
+    final int ncol = 5;
+
+    DMatrix dmat0 = null;
+    BigDenseMatrix data0 = null;
+    try {
+      data0 = new BigDenseMatrix(nrow, ncol);
+      //put random nums
+      Random random = new Random();
+      for (int i = 0; i < nrow * ncol; i++) {
+        data0.set(i, random.nextFloat());
+      }
+
+      //create label
+      float[] label0 = new float[nrow];
+      for (int i = 0; i < nrow; i++) {
+        label0[i] = random.nextFloat();
+      }
+
+      dmat0 = new DMatrix(data0);
+      dmat0.setLabel(label0);
+
+      //check
+      TestCase.assertTrue(dmat0.rowNum() == 10);
+      TestCase.assertTrue(dmat0.getLabel().length == 10);
+    } finally {
+      if (dmat0 != null) {
+        dmat0.dispose();
+      } else if (data0 != null){
+        data0.dispose();
+      }
+    }
+  }
+
+  @Test
+  public void testTrainWithDenseMatrixRef() throws XGBoostError {
+    Map<String, String> rabitEnv = new HashMap<>();
+    rabitEnv.put("DMLC_TASK_ID", "0");
+    Rabit.init(rabitEnv);
+    DMatrix trainMat = null;
+    BigDenseMatrix data0 = null;
+    try {
+      // trivial dataset with 3 rows and 2 columns
+      // (4,5) -> 1
+      // (3,1) -> 2
+      // (2,3) -> 3
+      float[][] data = new float[][]{
+              new float[]{4f, 5f},
+              new float[]{3f, 1f},
+              new float[]{2f, 3f}
+      };
+      data0 = new BigDenseMatrix(3, 2);
+      for (int i = 0; i < data0.nrow; i++)
+        for (int j = 0; j < data0.ncol; j++)
+          data0.set(i, j, data[i][j]);
+
+      trainMat = new DMatrix(data0);
+      trainMat.setLabel(new float[]{1f, 2f, 3f});
+
+      HashMap<String, Object> params = new HashMap<>();
+      params.put("eta", 1);
+      params.put("max_depth", 5);
+      params.put("silent", 1);
+      params.put("objective", "reg:linear");
+      params.put("seed", 123);
+
+      HashMap<String, DMatrix> watches = new HashMap<>();
+      watches.put("train", trainMat);
+
+      Booster booster = XGBoost.train(trainMat, params, 10, watches, null, null);
+
+      // check overfitting
+      // (4,5) -> 1
+      // (3,1) -> 2
+      // (2,3) -> 3
+      for (int i = 0; i < 3; i++) {
+        float[][] preds = booster.predict(new DMatrix(data[i], 1, 2));
+        Assert.assertEquals(1, preds.length);
+        Assert.assertArrayEquals(new float[]{(float) (i + 1)}, preds[0], 1e-2f);
+      }
+    } finally {
+      if (trainMat != null)
+        trainMat.dispose();
+      else if (data0 != null) {
+        data0.dispose();
+      }
+      Rabit.shutdown();
+    }
+  }
+
 }

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrixTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrixTest.java
@@ -1,9 +1,14 @@
 package ml.dmlc.xgboost4j.java.util;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class BigDenseMatrixTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testMatrix() {
@@ -24,6 +29,12 @@ public class BigDenseMatrixTest {
       if (matrix != null)
         matrix.dispose();;
     }
+  }
+
+  @Test
+  public void testMaxSize() {
+    thrown.expectMessage("Matrix too large; matrix size cannot exceed 2305843009213693951");
+    new BigDenseMatrix(Integer.MAX_VALUE, Integer.MAX_VALUE);
   }
 
 }

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrixTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/util/BigDenseMatrixTest.java
@@ -1,0 +1,29 @@
+package ml.dmlc.xgboost4j.java.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BigDenseMatrixTest {
+
+  @Test
+  public void testMatrix() {
+    final int nrow = 5;
+    final int ncol = 7;
+    BigDenseMatrix matrix = null;
+    try {
+      matrix = new BigDenseMatrix(nrow, ncol);
+
+      int val = 0;
+      for (int i = 0; i < nrow; i++)
+        for (int j = 0; j < ncol; j++)
+          matrix.set(i, j, val++);
+
+      for (int i = 0; i < nrow * ncol; i++)
+        Assert.assertEquals(i, matrix.get(i), 0);
+    } finally {
+      if (matrix != null)
+        matrix.dispose();;
+    }
+  }
+
+}


### PR DESCRIPTION
We can avoid using "2D" constructors in DMatrix by using off-heap memory
directly. 2D constructors have a lot of overhead associated with the flatten operation.

For large matrices, it can be an issue that the matrix is in native memory
2x and also 2 additional times in java memory (DKV and arrays).

This change will allows H2O to have the matrix represented in native memory just once and once in DKV.

Example use: https://github.com/h2oai/h2o-3/pull/2822