### PR TITLE
[BUILD] fix distro detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ metastore_db
 
 plugin/updater_gpu/test/cpp/data
 demo/
+cmake-build-debug

--- a/ci/Makefile.jenkins
+++ b/ci/Makefile.jenkins
@@ -82,11 +82,15 @@ $(info PATH=$(PATH))
 endif
 endif
 
-ifneq (,$(findstring CentOS,$(shell cat /etc/os-release 2> /dev/null)))
+ifneq (,$(findstring CentOS,$(shell cat /etc/system-release 2> /dev/null)))
     DISTRO := centos
 endif
 ifneq (,$(findstring Ubuntu,$(shell cat /etc/os-release 2> /dev/null)))
-	DISTRO := ubuntu
+    DISTRO := ubuntu
+endif
+
+ifeq ($(DISTRO),)
+    $(error Unable to identify OS/Distro.)
 endif
 
 ifeq ($(EXEC_PRECHECKS),1)


### PR DESCRIPTION
- distro detection was broken on CentOS fix it
- add check when distro detection fails again to avoid cryptic errors
- add build outputs to gitignore