### PR TITLE
[PUBDEV-6387] fix segfault when using gblinear

### DIFF
--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -139,7 +139,7 @@ class GradientBooster {
    */
   virtual std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                              bool with_stats,
-                                             std::string format) const = 0;
+                                             std::string format) = 0;
   /*!
    * \brief create a gradient booster from given name
    * \param name name of gradient booster

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -176,7 +176,8 @@ class GBLinear : public GradientBooster {
 
   std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                      bool with_stats,
-                                     std::string format) const override {
+                                     std::string format) override {
+    model_.LazyInitModel();
     return model_.DumpModel(fmap, with_stats, format);
   }
 

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -241,7 +241,7 @@ class GBTree : public GradientBooster {
 
   std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                      bool with_stats,
-                                     std::string format) const override {
+                                     std::string format) override {
     return model_.DumpModel(fmap, with_stats, format);
   }
 


### PR DESCRIPTION
- gblinear models require LazyInit to be called before anything is done to the model
- since DumpModel was marked as const this was not possible since LazyInit is not const
- make DumpModel not const and add call to LazyInit in DumpModel